### PR TITLE
Add required environment variables to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,15 @@
   "name":"situational",
   "scripts":{},
   "env":{
-      "DJANGO_SETTINGS_MODULE": "situational.settings.heroku"
+    "AWS_ACCESS_KEY_ID"      :{"required":true},
+    "AWS_S3_HOST"            :{"required":true},
+    "AWS_SECRET_ACCESS_KEY"  :{"required":true},
+    "AWS_STORAGE_BUCKET_NAME":{"required":true},
+    "DJANGO_SETTINGS_MODULE" :"situational.settings.heroku",
+    "ENABLE_MAPUMENTAL"      :{"required":true},
+    "HTTP_PASSWORD"          :{"required":true},
+    "HTTP_USERNAME"          :{"required":true},
+    "MAPUMENTAL_API_KEY"     :{"required":true}
   },
    "addons":[
     "heroku-postgresql:hobby-dev",


### PR DESCRIPTION
ENV variables marked as required will be inherited from the "parent" application (if one exists) for new Heroku forks.

We still need to run `heroku ps:scale celery=1 --app <review-app-name>` manually, but at least this means not wrangling env variables for review apps!
