### PR TITLE
Seperate out print styles

### DIFF
--- a/situational/apps/detailed_history/templates/detailed_history/print.html
+++ b/situational/apps/detailed_history/templates/detailed_history/print.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <title>Understand where you could travel for work</title>
-  {% embed_stylesheet "css/detailed-history-print.scss" %}
+  {% embed_stylesheet "print/css/detailed-history.scss" %}
 </head>
 <body>
   <h1>Tell your work coach your history</h1>

--- a/situational/apps/sectors/templates/sectors/print.html
+++ b/situational/apps/sectors/templates/sectors/print.html
@@ -5,97 +5,89 @@
 <html>
 <head>
   <title>Understand what sort of jobs you could do</title>
-  {% embed_stylesheet "css/report-print.scss" %}
+  {% embed_stylesheet "print/css/sectors.scss" %}
 </head>
 <body>
-<div class="row">
-  <div class="columns">
-    <article class="report clearfix">
-      <header>
-        <h1>Understand what sort of jobs you could do</h1>
-        <p>This report contains information about the jobs you selected. It helps you understand what is required of each job, approximate hours and pay, and terms to use when searching for them online.</p>
-      </header>
+  <article class="report clearfix">
+    <header>
+      <h1>Understand what sort of jobs you could do</h1>
+      <p>This report contains information about the jobs you selected. It helps you understand what is required of each job, approximate hours and pay, and terms to use when searching for them online.</p>
+    </header>
 
-      {% for soc_code,soc_data in report.soc_code_data.items %}
-
-        <section>
-          <div class="columns job_item">
-            <header>
-              <h2>{{ soc_data.info.title }}</h2>
-            </header>
-
-            <p>{{ soc_data.info.description }}</p>
-
-            <div class="row">
-              <div class="large-6 columns">
-                <h4>Typical pay and hours</h4>
-                <ul>
-                  <li>Normal hours worked per week: {{ soc_data.hours_worked }}</li>
-                  <li>Estimated weekly pay: &pound;{{ soc_data.pay|intcomma }}</li>
-                </ul>
-              </div>
-
-              <div class="large-6 columns">
-                <h4>Typical qualifications required</h4>
-                <p>{{ soc_data.info.qualifications }}</p>
-              </div>
-            </div>
-
-            <div class="row">
-              <div class="large-6 columns">
-                <h4>Typical tasks</h4>
-                <ul>
-                  {% for task in soc_data.info.tasks %}
-                    <li>{{ task|capfirst }}</li>
-                  {% endfor %}
-                </ul>
-              </div>
-
-              <div class="large-6 columns">
-                <h4>Useful search terms</h4>
-                  <em>{{ soc_data.info.add_titles|slice:":20"|join:", " }}</em>
-              </div>
-            </div>
-          </div>
-        </section>
-
-      {% endfor %}
+    {% for soc_code,soc_data in report.soc_code_data.items %}
 
       <section>
-        <div class="columns">
-          <div class="panel">
-            <header>
-              <h2>Local area - based on UK Census data</h2>
-            </header>
-            <div class="row">
-              <div class="columns large-6">
-                <h3>Jobs in the area</h3>
-                <ul>
-                {% for job in report.jobs_breakdown %}
-                  <li>{{ job.description }}</li>
-                {% endfor %}
-                </ul>
-              </div>
+          <header>
+            <h2>{{ soc_data.info.title }}</h2>
+          </header>
 
-              <div class="columns large-6">
-                <h3>Resident professions</h3>
-                <ul>
-                {% for job in report.resident_occupations %}
-                  <li>{{ job.description|title }}</li>
-                {% endfor %}
-                </ul>
-              </div>
+          <p>{{ soc_data.info.description }}</p>
+
+          <div class="row">
+            <div class="print-6 columns">
+              <h4>Typical pay and hours</h4>
+              <ul>
+                <li>Normal hours worked per week: {{ soc_data.hours_worked }}</li>
+                <li>Estimated weekly pay: &pound;{{ soc_data.pay|intcomma }}</li>
+              </ul>
+            </div>
+
+            <div class="print-6 columns">
+              <h4>Typical qualifications required</h4>
+              <p>{{ soc_data.info.qualifications }}</p>
             </div>
           </div>
-        </div>
+
+          <div class="row">
+            <div class="print-6 columns">
+              <h4>Typical tasks</h4>
+              <ul>
+                {% for task in soc_data.info.tasks %}
+                  <li>{{ task|capfirst }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+
+            <div class="print-6 columns">
+              <h4>Useful search terms</h4>
+                <em>{{ soc_data.info.add_titles|slice:":20"|join:", " }}</em>
+            </div>
+          </div>
       </section>
 
-      <footer>
-        <p>Let us know if this is useful at <strong>feedback@lm-tools.com</strong></p>
-      </footer>
-    </article>
-  </div>
-</div>
+    {% endfor %}
+
+    <section>
+      <div class="panel">
+        <header>
+          <h2>Local area - based on UK Census data</h2>
+        </header>
+        <div class="row">
+          <div class="columns print-6">
+            <h3>Jobs in the area</h3>
+            <ul>
+            {% for job in report.jobs_breakdown %}
+              <li>{{ job.description }}</li>
+            {% endfor %}
+            </ul>
+          </div>
+
+          <div class="columns print-6">
+            <h3>Resident professions</h3>
+            <ul>
+            {% for job in report.resident_occupations %}
+              <li>{{ job.description|title }}</li>
+            {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <p>Let us know if this is useful at <strong>feedback@lm-tools.com</strong></p>
+    </footer>
+  </article>
 
 </body>
 </html>

--- a/situational/apps/travel_report/templates/travel_report/print.html
+++ b/situational/apps/travel_report/templates/travel_report/print.html
@@ -3,32 +3,30 @@
 <html>
 <head>
   <title>Understand where you could travel for work</title>
-  {% embed_stylesheet "css/report-print.scss" %}
+  {% embed_stylesheet "print/css/travel.scss" %}
 </head>
 <body>
-<div class="row">
-  <div class="columns">
-    <article class="report clearfix">
-      <header>
-        <h1>Understand where you could travel for work</h1>
-        <p>This report contains information to help you understand travel time and costs when you are looking for work.</p>
-      </header>
+  <article class="report clearfix">
+    <header>
+      <h1>Understand where you could travel for work</h1>
+      <p>This report contains information to help you understand travel time and costs when you are looking for work.</p>
+    </header>
 
-      <section>
-        <div class="columns small-centered">
-          <header>
-            <h3>Travel times from {{ report.postcode }} on public transport</h3>
-          </header>
+    <section>
+      <header>
+        <h3>Travel times from {{ report.postcode }} on public transport</h3>
+      </header>
+      <div class="row">
+        <div class="column print-11 print-centered">
           <p><img src="{% dataurl report.travel_times_map.image mimetype=report.travel_times_map.mime_type %}"></p>
         </div>
-      </section>
+      </div>
+    </section>
 
-      <footer>
-        <p>Let us know if this is useful at <strong>feedback@lm-tools.com</strong></p>
-      </footer>
-    </article>
-  </div>
-</div>
+    <footer>
+      <p>Let us know if this is useful at <strong>feedback@lm-tools.com</strong></p>
+    </footer>
+  </article>
 
 </body>
 </html>

--- a/situational/assets/css/detailed-history-print.scss
+++ b/situational/assets/css/detailed-history-print.scss
@@ -1,2 +1,0 @@
-@import 'styles.scss';
-@import 'timeline.scss';

--- a/situational/assets/print/css/_print-grid.scss
+++ b/situational/assets/print/css/_print-grid.scss
@@ -1,0 +1,5 @@
+@import '../foundation-print/scss/foundation/components/grid';
+
+@include exports("print-grid") {
+  @include grid-html-classes($size:print);
+}

--- a/situational/assets/print/css/_report-print.scss
+++ b/situational/assets/print/css/_report-print.scss
@@ -1,7 +1,3 @@
-$base-font-size: 100%;
-
-@import 'styles.scss';
-
 footer {
   text-align: center;
 }
@@ -11,11 +7,15 @@ body.has-report {
 }
 
 .report {
+  margin-left: -30px;
+  margin-right: -30px;
+
   > header {
-    margin-top: 2%;
+    margin-top: 1%;
   }
 
   section {
+    page-break-inside: avoid;
     margin-bottom: 1%;
     header {
       padding-top: 1%;

--- a/situational/assets/print/css/detailed-history.scss
+++ b/situational/assets/print/css/detailed-history.scss
@@ -1,0 +1,3 @@
+@import 'print-styles.scss';
+
+// detailed-history specific print styles go here

--- a/situational/assets/print/css/print-styles.scss
+++ b/situational/assets/print/css/print-styles.scss
@@ -1,0 +1,6 @@
+@import '../foundation-print/scss/normalize';
+@import '../foundation-print/scss/foundation';
+@import '_print-grid';
+
+@import '../../css/_report';
+@import '_report-print';

--- a/situational/assets/print/css/sectors.scss
+++ b/situational/assets/print/css/sectors.scss
@@ -1,0 +1,3 @@
+@import 'print-styles.scss';
+
+// sectors specific print styles go here

--- a/situational/assets/print/css/travel.scss
+++ b/situational/assets/print/css/travel.scss
@@ -1,0 +1,3 @@
+@import 'print-styles.scss';
+
+// travel report specific print styles go here

--- a/situational/assets/print/foundation-print/scss/foundation.scss
+++ b/situational/assets/print/foundation-print/scss/foundation.scss
@@ -1,0 +1,42 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+// Behold, here are all the Foundation components.
+@import 'foundation/components/grid';
+@import 'foundation/components/accordion';
+@import 'foundation/components/alert-boxes';
+@import 'foundation/components/block-grid';
+@import 'foundation/components/breadcrumbs';
+@import 'foundation/components/button-groups';
+@import 'foundation/components/buttons';
+@import 'foundation/components/clearing';
+@import 'foundation/components/dropdown';
+@import 'foundation/components/dropdown-buttons';
+@import 'foundation/components/flex-video';
+@import 'foundation/components/forms';
+@import 'foundation/components/icon-bar';
+@import 'foundation/components/inline-lists';
+@import 'foundation/components/joyride';
+@import 'foundation/components/keystrokes';
+@import 'foundation/components/labels';
+@import 'foundation/components/magellan';
+@import 'foundation/components/orbit';
+@import 'foundation/components/pagination';
+@import 'foundation/components/panels';
+@import 'foundation/components/pricing-tables';
+@import 'foundation/components/progress-bars';
+@import 'foundation/components/range-slider';
+@import 'foundation/components/reveal';
+@import 'foundation/components/side-nav';
+@import 'foundation/components/split-buttons';
+@import 'foundation/components/sub-nav';
+@import 'foundation/components/switches';
+@import 'foundation/components/tables';
+@import 'foundation/components/tabs';
+@import 'foundation/components/thumbs';
+@import 'foundation/components/tooltips';
+@import 'foundation/components/top-bar';
+@import 'foundation/components/type';
+@import 'foundation/components/offcanvas';
+@import 'foundation/components/visibility';

--- a/situational/assets/print/foundation-print/scss/foundation/_functions.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/_functions.scss
@@ -1,0 +1,173 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+// This is the default html and body font-size for the base rem value.
+$rem-base: 16px !default;
+
+// IMPORT ONCE
+// We use this to prevent styles from being loaded multiple times for components that rely on other components.
+$modules: () !default;
+
+@mixin exports($name) {
+  // Import from global scope
+  $modules: $modules !global;
+  // Check if a module is already on the list
+  $module_index: index($modules, $name);
+  @if (($module_index == null) or ($module_index == false)) {
+    $modules: append($modules, $name) !global;
+    @content;
+  }
+}
+
+//
+// @functions
+//
+
+
+// RANGES
+// We use these functions to define ranges for various things, like media queries.
+@function lower-bound($range) {
+  @if length($range) <= 0 {
+    @return 0;
+  }
+  @return nth($range, 1);
+}
+
+@function upper-bound($range) {
+  @if length($range) < 2 {
+    @return 999999999999;
+  }
+  @return nth($range, 2);
+}
+
+// STRIP UNIT
+// It strips the unit of measure and returns it
+@function strip-unit($num) {
+  @return $num / ($num * 0 + 1);
+}
+
+// TEXT INPUT TYPES
+
+@function text-inputs( $types: all, $selector: input ) {
+
+  $return: ();
+
+  $all-text-input-types:
+    text
+    password
+    date
+    datetime
+    datetime-local
+    month
+    week
+    email
+    number
+    search
+    tel
+    time
+    url
+    color
+    textarea;
+
+  @if $types == all { $types: $all-text-input-types; }
+
+  @each $type in $types {
+    @if $type == textarea {
+      @if $selector == input {
+        $return: append($return, unquote('#{$type}'), comma)
+      } @else {
+        $return: append($return, unquote('#{$type}#{$selector}'), comma)
+      }
+    } @else {
+      $return: append($return, unquote('#{$selector}[type="#{$type}"]'), comma)
+    }
+  }
+
+    @return $return;
+
+}
+
+// CONVERT TO REM
+@function convert-to-rem($value, $base-value: $rem-base) {
+  $value: strip-unit($value) / strip-unit($base-value) * 1rem;
+  @if ($value == 0rem) { $value: 0; } // Turn 0rem into 0
+  @return $value;
+}
+
+@function data($attr) {
+  @if $namespace {
+    @return '[data-' + $namespace + '-' + $attr + ']';
+  }
+
+  @return '[data-' + $attr + ']';
+}
+
+// REM CALC
+
+// New Syntax, allows to optionally calculate on a different base value to counter compounding effect of rem's.
+// Call with 1, 2, 3 or 4 parameters, 'px' is not required but supported:
+//
+//   rem-calc(10 20 30px 40);
+//
+// Space delimited, if you want to delimit using comma's, wrap it in another pair of brackets
+//
+//   rem-calc((10, 20, 30, 40px));
+//
+// Optionally call with a different base (eg: 8px) to calculate rem.
+//
+//   rem-calc(16px 32px 48px, 8px);
+//
+// If you require to comma separate your list
+//
+//   rem-calc((16px, 32px, 48), 8px);
+
+@function px($rem) {
+  @return strip-unit($rem) * $rem-base;
+}
+
+@function rem-calc($values, $base-value: $rem-base) {
+  $max: length($values);
+
+  @if $max == 1 { @return px(convert-to-rem(nth($values, 1), $base-value)); }
+
+  $remValues: ();
+  @for $i from 1 through $max {
+    $remValues: append($remValues, px(convert-to-rem(nth($values, $i), $base-value)));
+  }
+  @return $remValues;
+}
+
+@function rem-calc-original($values, $base-value: $rem-base) {
+  $max: length($values);
+
+  @if $max == 1 { @return convert-to-rem(nth($values, 1), $base-value); }
+
+  $remValues: ();
+  @for $i from 1 through $max {
+    $remValues: append($remValues, convert-to-rem(nth($values, $i), $base-value));
+  }
+  @return $remValues;
+}
+
+
+
+@function em-calc($values, $base-value: $rem-base) {
+  $remValues: rem-calc-original($values, $base-value: $rem-base);
+
+  $max: length($remValues);
+
+  @if $max == 1 { @return strip-unit(nth($remValues, 1)) * 1em; }
+
+  $emValues: ();
+  @for $i from 1 through $max {
+    $emValues: append($emValues, strip-unit(nth($remValues, $i)) * 1em);
+  }
+  @return $emValues;
+}
+
+
+// Deprecated: OLD EM CALC
+@function emCalc($values) {
+  @return em-calc($values);
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_accordion.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_accordion.scss
@@ -1,0 +1,160 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+
+$include-html-accordion-classes: $include-html-classes !default;
+
+$accordion-navigation-padding: rem-calc(16) !default;
+$accordion-navigation-bg-color: $silver !default;
+$accordion-navigation-hover-bg-color: scale-color($accordion-navigation-bg-color, $lightness: -5%) !default;
+$accordion-navigation-active-bg-color: scale-color($accordion-navigation-bg-color, $lightness: -3%) !default;
+$accordion-navigation-active-font-color: $jet !default;
+$accordion-navigation-font-color: $jet !default;
+$accordion-navigation-font-size: rem-calc(16) !default;
+$accordion-navigation-font-family: $body-font-family !default;
+
+$accordion-content-padding: ($column-gutter/2) !default;
+$accordion-content-active-bg-color: $white !default;
+
+
+//  Mixin: accordion-container()
+//  Decription: Responsible for the container component of accordions, generating styles relating to a margin of zero and a clearfix
+//  Explicit Dependencies: a clearfix mixin *is* defined.
+//  Implicit Dependencies: None
+
+@mixin accordion-container() {
+  @include clearfix;
+  margin-bottom: 0;
+}
+
+//  Mixin: accordion-navigation( $bg, $hover-bg, $active-bg, $padding, $active_class,  $font-color, $font-size, $font-family) {
+//    @params $bg-color: [ color or string ]: Specify the background color for the navigation element
+//    @params $hover-bg-color [ color or string ]: Specify the background color for the navigation element when hovered
+//    @params $active-bg [ color or string ]: Specify the background color for the navigation element when clicked and not released.
+//    @params $active_class [ string ]: Specify the class name used to keep track of which accordion tab should be visible
+//    @params $font-color [ color or string ]: Color of the font for accordion
+//    @params $font-size [ number ]: Specifiy the font-size of the text inside the navigation element
+//    @params $font-family [ string ]: Specify the font family for the text of the navigation of the accorion
+//    @params $active-font [ color or string ]: Specify the font color for the navigation element when active.
+
+@mixin accordion-navigation( $bg: $accordion-navigation-bg-color, $hover-bg: $accordion-navigation-hover-bg-color, $active-bg: $accordion-navigation-active-bg-color, $padding: $accordion-navigation-padding, $active_class: 'active',  $font-color: $accordion-navigation-font-color, $font-size: $accordion-navigation-font-size, $font-family: $accordion-navigation-font-family, $active-font: $accordion-navigation-active-font-color ) {
+  display: block;
+  margin-bottom: 0 !important;
+  @if type-of($active_class) != "string" {
+    @warn "`#{$active_class}` isn't a valid string. A valid string is needed to correctly be interpolated as a CSS class. CSS classes cannot start with a number or consist of only numbers. CSS will not be generated for the active state of this navigation component."
+  }
+  @else {
+    &.#{ $active_class } > a {
+      background: $active-bg;
+      color: $active-font;
+    }
+  }
+  > a {
+    background: $bg;
+    color: $font-color;
+    @if type-of($padding) != number {
+      @warn "`#{$padding}` was read as #{type-of($padding)}";
+      @if $accordion-navigation-padding != null {
+        @warn "#{$padding} was read as a #{type-of($padding)}";
+        @warn "`#{$padding}` isn't a valid number. $accordion-navigation-padding (#{$accordion-navigation-padding}) will be used instead.)";
+        padding: $accordion-navigation-padding;
+      }
+      @else {
+        @warn "`#{$padding}` isn't a valid number and $accordion-navigation-padding is missing. A value of `null` is returned to not output an invalid value for padding";
+        padding: null;
+      }
+    }
+    @else {
+      padding: $padding;
+    }
+    display: block;
+    font-family: $font-family;
+    @if type-of($font-size) != number {
+      @warn "`#{$font-size}` was read as a #{type-of($font-size)}";
+      @if $accordion-navigation-font-size != null {
+        @warn "`#{$font-size}` is not a valid number. The value of $accordion-navigation-font-size will be used instead (#{$accordion-navigation-font-size}).";
+        font-size: $accordion-navigation-font-size;
+      }
+      @else{
+        @warn "`#{$font-size}` is not a valid number and the default value of $accordion-navigation-font-size is not defined. A value of `null` will be returned to not generate an invalid value for font-size.";
+        font-size: null;
+
+      }
+    }
+    @else {
+      font-size: $font-size;
+    }
+    &:hover {
+      background: $hover-bg;
+    }
+  }
+}
+
+//  Mixin: accordion-content($bg, $padding, $active-class)
+//    @params $padding [ number ]: Padding for the content of the container
+//    @params $bg [ color  ]: Background color for the content when it's visible
+//    @params $active_class [ string ]: Class name used to keep track of which accordion tab should be visible.
+
+@mixin accordion-content($bg: $accordion-content-active-bg-color, $padding: $accordion-content-padding, $active_class: 'active') {
+  display: none;
+  @if type-of($padding) != "number" {
+    @warn "#{$padding} was read as a #{type-of($padding)}";
+    @if $accordion-content-padding != null {
+      @warn "`#{$padding}` isn't a valid number. $accordion-content-padding used instead";
+      padding: $accordion-content-padding;
+    } @else {
+      @warn "`#{$padding}` isn't a valid number and the default value of $accordion-content-padding is not defined. A value of `null` is returned to not output an invalid value for padding.";
+      padding: null;
+    }
+  } @else {
+    padding: $padding;
+  }
+
+  @if type-of($active_class) != "string" {
+    @warn "`#{$active_class}` isn't a valid string. A valid string is needed to correctly be interpolated as a CSS class. CSS classes cannot start with a number or consist of only numbers. CSS will not be generated for the active state of the content. "
+  }
+  @else {
+    &.#{$active_class} {
+      background: $bg;
+      display: block;
+    }
+  }
+}
+
+@include exports("accordion") {
+  @if $include-html-accordion-classes {
+    .accordion {
+      @include clearfix;
+      margin-bottom: 0;
+      .accordion-navigation, dd {
+        display: block;
+        margin-bottom: 0 !important;
+        &.active > a { background: $accordion-navigation-active-bg-color; color: $accordion-navigation-active-font-color; }
+        > a {
+          background: $accordion-navigation-bg-color;
+          color: $accordion-navigation-font-color;
+          display: block;
+          font-family: $accordion-navigation-font-family;
+          font-size: $accordion-navigation-font-size;
+          padding: $accordion-navigation-padding;
+          &:hover { background: $accordion-navigation-hover-bg-color; }
+        }
+
+        > .content {
+          display: none;
+          padding: $accordion-content-padding;
+          &.active {
+            background: $accordion-content-active-bg-color;
+            display: block;
+          }
+        }
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_alert-boxes.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_alert-boxes.scss
@@ -1,0 +1,128 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// Alert Box Variables
+//
+$include-html-alert-classes: $include-html-classes !default;
+
+// We use this to control alert padding.
+$alert-padding-top: rem-calc(14) !default;
+$alert-padding-default-float: $alert-padding-top !default;
+$alert-padding-opposite-direction: $alert-padding-top + rem-calc(10) !default;
+$alert-padding-bottom: $alert-padding-top !default;
+
+// We use these to control text style.
+$alert-font-weight: $font-weight-normal !default;
+$alert-font-size: rem-calc(13) !default;
+$alert-font-color: $white !default;
+$alert-font-color-alt: scale-color($secondary-color, $lightness: -66%) !default;
+
+// We use this for close hover effect.
+$alert-function-factor: -14% !default;
+
+// We use these to control border styles.
+$alert-border-style: solid !default;
+$alert-border-width: 1px !default;
+$alert-border-color: scale-color($primary-color, $lightness: $alert-function-factor) !default;
+$alert-bottom-margin: rem-calc(20) !default;
+
+// We use these to style the close buttons
+$alert-close-color: $oil !default;
+$alert-close-top: 50% !default;
+$alert-close-position: rem-calc(4) !default;
+$alert-close-font-size: rem-calc(22) !default;
+$alert-close-opacity: .3 !default;
+$alert-close-opacity-hover: .5 !default;
+$alert-close-padding: 0 6px 4px !default;
+$alert-close-background: inherit !default;
+
+// We use this to control border radius
+$alert-radius: $global-radius !default;
+
+$alert-transition-speed: 300ms !default;
+$alert-transition-ease: ease-out !default;
+
+//
+// Alert Mixins
+//
+
+// We use this mixin to create a default alert base.
+@mixin alert-base {
+  border-style: $alert-border-style;
+  border-width: $alert-border-width;
+  display: block;
+  font-size: $alert-font-size;
+  font-weight: $alert-font-weight;
+  margin-bottom: $alert-bottom-margin;
+  padding: $alert-padding-top $alert-padding-opposite-direction $alert-padding-bottom $alert-padding-default-float;
+  position: relative;
+  @include single-transition(opacity, $alert-transition-speed, $alert-transition-ease)
+}
+
+// We use this mixin to add alert styles
+//
+// $bg - The background of the alert. Default: $primary-color.
+@mixin alert-style($bg:$primary-color) {
+
+  // This finds the lightness percentage of the background color.
+  $bg-lightness: lightness($bg);
+
+  // We control which background color and border come through.
+  background-color: $bg;
+  border-color: scale-color($bg, $lightness: $alert-function-factor);
+
+  // We control the text color for you based on the background color.
+  @if $bg-lightness > 70% { color: $alert-font-color-alt; }
+  @else                   { color: $alert-font-color; }
+
+}
+
+// We use this to create the close button.
+@mixin alert-close {
+  #{$opposite-direction}: $alert-close-position;
+  background: $alert-close-background;
+  color: $alert-close-color;
+  font-size: $alert-close-font-size;
+  line-height: .9;
+  margin-top: -($alert-close-font-size / 2);
+  opacity: $alert-close-opacity;
+  padding: $alert-close-padding;
+  position: absolute;
+  top: $alert-close-top;
+  &:hover,
+  &:focus { opacity: $alert-close-opacity-hover; }
+}
+
+// We use this to quickly create alerts with a single mixin.
+//
+// $bg - Background of alert. Default: $primary-color.
+// $radius - Radius of alert box. Default: false.
+@mixin alert($bg:$primary-color, $radius:false) {
+  @include alert-base;
+  @include alert-style($bg);
+  @include radius($radius);
+}
+
+@include exports("alert-box") {
+  @if $include-html-alert-classes {
+    .alert-box {
+      @include alert;
+
+      .close      { @include alert-close; }
+
+      &.radius    { @include radius($alert-radius); }
+      &.round     { @include radius($global-rounded); }
+
+      &.success   { @include alert-style($success-color); }
+      &.alert     { @include alert-style($alert-color); }
+      &.secondary { @include alert-style($secondary-color); }
+      &.warning { @include alert-style($warning-color); }
+      &.info { @include alert-style($info-color); }
+      &.alert-close { opacity: 0}
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_block-grid.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_block-grid.scss
@@ -1,0 +1,133 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// Block Grid Variables
+//
+$include-html-block-grid-classes: $include-html-classes !default;
+$include-xl-html-block-grid-classes: false !default;
+
+// We use this to control the maximum number of block grid elements per row
+$block-grid-elements: 12 !default;
+$block-grid-default-spacing: rem-calc(20) !default;
+
+$align-block-grid-to-grid: false !default;
+@if $align-block-grid-to-grid {
+  $block-grid-default-spacing: $column-gutter;
+}
+
+// Enables media queries for block-grid classes. Set to false if writing semantic HTML.
+$block-grid-media-queries: true !default;
+
+//
+// Block Grid Mixins
+//
+
+// Create a custom block grid
+//
+// $per-row - # of items to display per row. Default: false.
+// $spacing - # of ems to use as padding on each block item. Default: rem-calc(20).
+// $include-spacing - Adds padding to our list item. Default: true.
+// $base-style - Apply a base style to block grid. Default: true.
+@mixin block-grid(
+  $per-row:false,
+  $spacing:$block-grid-default-spacing,
+  $include-spacing:true,
+  $base-style:true) {
+
+  @if $base-style {
+    display: block;
+    padding: 0;
+    @if $align-block-grid-to-grid {
+      margin: 0;
+    } @else {
+      margin: 0 (-$spacing/2);
+    }
+    @include clearfix;
+
+    > li {
+      display: block;
+      float: $default-float;
+      height: auto;
+      @if $include-spacing {
+        padding: 0 ($spacing/2) $spacing;
+      }
+    }
+  }
+
+  @if $per-row {
+    > li {
+      list-style: none;
+      @if $include-spacing {
+        padding: 0 ($spacing/2) $spacing;
+      }
+      width: 100%/$per-row;
+
+      &:nth-of-type(1n) { clear: none; }
+      &:nth-of-type(#{$per-row}n+1) { clear: both; }
+      @if $align-block-grid-to-grid {
+        @include block-grid-aligned($per-row, $spacing);
+      }
+    }
+  }
+}
+
+@mixin block-grid-aligned($per-row, $spacing) {
+  @for $i from 1 through $block-grid-elements {
+    @if $per-row >= $i {
+      $grid-column: '+' + $i;
+      @if $per-row == $i {
+        $grid-column: '';
+      }
+      &:nth-of-type(#{$per-row}n#{unquote($grid-column)}) {
+        padding-left: ($spacing - (($spacing / $per-row) * ($per-row - ($i - 1))));
+        padding-right: ($spacing - (($spacing / $per-row) * $i));
+      }
+    }
+  }
+}
+
+// Generate presentational markup for block grid.
+//
+// $size - Name of class to use, i.e. "large" will generate .large-block-grid-1, .large-block-grid-2, etc.
+@mixin block-grid-html-classes($size, $include-spacing) {
+  @for $i from 1 through $block-grid-elements {
+    .#{$size}-block-grid-#{($i)} {
+      @include block-grid($i, $block-grid-default-spacing, $include-spacing, false);
+    }
+  }
+}
+
+@include exports("block-grid") {
+  @if $include-html-block-grid-classes {
+
+    [class*="block-grid-"] { @include block-grid; }
+
+    @if $block-grid-media-queries {
+      @media #{$small-up} {
+        @include block-grid-html-classes($size:small, $include-spacing:false);
+      }
+
+      @media #{$medium-up} {
+        @include block-grid-html-classes($size:medium, $include-spacing:false);
+      }
+
+      @media #{$large-up} {
+        @include block-grid-html-classes($size:large, $include-spacing:false);
+      }
+
+      @if $include-xl-html-block-grid-classes {
+        @media #{$xlarge-up} {
+          @include block-grid-html-classes($size:xlarge, $include-spacing:false);
+        }
+
+        @media #{$xxlarge-up} {
+          @include block-grid-html-classes($size:xxlarge, $include-spacing:false);
+        }
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_breadcrumbs.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_breadcrumbs.scss
@@ -1,0 +1,131 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// Breadcrumb Variables
+//
+$include-html-nav-classes: $include-html-classes !default;
+
+// We use this to set the background color for the breadcrumb container.
+$crumb-bg: scale-color($secondary-color, $lightness: 55%) !default;
+
+// We use these to set the padding around the breadcrumbs.
+$crumb-padding: rem-calc(9 14 9) !default;
+$crumb-side-padding: rem-calc(12) !default;
+
+// We use these to control border styles.
+$crumb-function-factor: -10% !default;
+$crumb-border-size: 1px !default;
+$crumb-border-style: solid !default;
+$crumb-border-color: scale-color($crumb-bg, $lightness: $crumb-function-factor) !default;
+$crumb-radius: $global-radius !default;
+
+// We use these to set various text styles for breadcrumbs.
+$crumb-font-size: rem-calc(11) !default;
+$crumb-font-color: $primary-color !default;
+$crumb-font-color-current: $oil !default;
+$crumb-font-color-unavailable: $aluminum !default;
+$crumb-font-transform: uppercase !default;
+$crumb-link-decor: underline !default;
+
+// We use these to control the slash between breadcrumbs
+$crumb-slash-color: $base !default;
+$crumb-slash: "/" !default;
+
+//
+// Breadcrumb Mixins
+//
+
+// We use this mixin to create a container around our breadcrumbs
+@mixin crumb-container {
+  border-style: $crumb-border-style;
+  border-width: $crumb-border-size;
+  display: block;
+  list-style: none;
+  margin-#{$default-float}: 0;
+  overflow: hidden;
+  padding: $crumb-padding;
+
+  // We control which background color and border come through.
+  background-color: $crumb-bg;
+  border-color: $crumb-border-color;
+}
+
+// We use this mixin to create breadcrumb styles from list items.
+@mixin crumbs {
+
+  // A normal state will make the links look and act like clickable breadcrumbs.
+  color: $crumb-font-color;
+  float: $default-float;
+  font-size: $crumb-font-size;
+  line-height: $crumb-font-size;
+  margin: 0;
+  text-transform: $crumb-font-transform;
+
+  &:hover a, &:focus a { text-decoration: $crumb-link-decor; }
+
+  a {
+    color: $crumb-font-color;
+  }
+
+  // Current is for the link of the current page
+  &.current {
+    color: $crumb-font-color-current;
+    cursor: $cursor-default-value;
+    a {
+      color: $crumb-font-color-current;
+      cursor: $cursor-default-value;
+    }
+
+    &:hover, &:hover a,
+    &:focus, &:focus a { text-decoration: none; }
+  }
+
+  // Unavailable removed color and link styles so it looks inactive.
+  &.unavailable {
+    color: $crumb-font-color-unavailable;
+    a { color: $crumb-font-color-unavailable; }
+
+    &:hover,
+    &:hover a,
+    &:focus,
+    a:focus {
+      color: $crumb-font-color-unavailable;
+      cursor: $cursor-disabled-value;
+      text-decoration: none;
+    }
+  }
+
+  &:before {
+    color: $crumb-slash-color;
+    content: "#{$crumb-slash}";
+    margin: 0 $crumb-side-padding;
+    position: relative;
+    top: 1px;
+  }
+
+  &:first-child:before {
+    content: " ";
+    margin: 0;
+  }
+}
+
+@include exports("breadcrumbs") {
+  @if $include-html-nav-classes {
+    .breadcrumbs {
+      @include crumb-container;
+      @include radius($crumb-radius);
+
+      > * {
+        @include crumbs;
+      }
+    }
+    /* Accessibility - hides the forward slash */
+    [aria-label="breadcrumbs"] [aria-hidden="true"]:after {
+      content: "/";
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_button-groups.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_button-groups.scss
@@ -1,0 +1,208 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+@import 'buttons';
+
+//
+// Button Group Variables
+//
+$include-html-button-classes: $include-html-classes !default;
+
+// Sets the margin for the right side by default, and the left margin if right-to-left direction is used
+$button-bar-margin-opposite: rem-calc(10) !default;
+$button-group-border-width: 1px !default;
+
+//
+// Button Group Mixins
+//
+
+// We use this to add styles for a button group container
+@mixin button-group-container($styles:true, $float:false) {
+  @if $styles {
+    list-style: none;
+    margin: 0;
+    #{$default-float}: 0;
+    @include clearfix();
+  }
+  @if $float {
+    float: #{$default-float};
+    margin-#{$opposite-direction}: $button-bar-margin-opposite;
+    & div { overflow: hidden; }
+  }
+}
+
+// We use this to control styles for button groups
+@mixin button-group-style($radius:false, $even:false, $float:false, $orientation:horizontal) {
+
+  > button, .button {
+    border-#{$default-float}: $button-group-border-width solid;
+    border-color: rgba(255, 255, 255, .5);
+  }
+
+  &:first-child {
+    button, .button {
+      border-#{$default-float}: 0;
+    }
+  }
+
+  $button-group-display: list-item;
+  $button-group-margin: 0;
+
+  // We use this to control the flow, or remove those styles completely.
+  @if $float {
+    $button-group-display: list-item;
+    $button-group-margin: 0;
+    float: $float;
+    // Make sure the first child doesn't get the negative margin.
+    &:first-child { margin-#{$default-float}: 0; }
+  }
+  @else {
+    $button-group-display: inline-block;
+    $button-group-margin: 0 -2px;
+  }
+
+  @if $orientation == vertical {
+    $button-group-display: block;
+    $button-group-margin: 0;
+    > button, .button {
+      border-color: rgba(255, 255, 255, .5);
+      border-left-width: 0;
+      border-top: $button-group-border-width solid;
+      display: block;
+      margin:0;
+    }
+    > button {
+        width: 100%;
+    }
+
+    &:first-child {
+      button, .button {
+        border-top: 0;
+      }
+    }
+  }
+
+  display: $button-group-display;
+  margin: $button-group-margin;
+
+
+  // We use these to control left and right radius on first/last buttons in the group.
+  @if $radius == true {
+    &,
+    > a,
+    > button,
+    > .button { @include radius(0); }
+    &:first-child,
+    &:first-child > a,
+    &:first-child > button,
+    &:first-child > .button {
+      @if $orientation == vertical {
+        @include side-radius(top, $button-radius);
+      }
+      @else {
+        @include side-radius($default-float, $button-radius);
+      }
+    }
+    &:last-child,
+    &:last-child > a,
+    &:last-child > button,
+    &:last-child > .button {
+      @if $orientation == vertical {
+        @include side-radius(bottom, $button-radius);
+      }
+      @else {
+        @include side-radius($opposite-direction, $button-radius);
+      }
+    }
+  }
+  @else if $radius {
+    &,
+    > a,
+    > button,
+    > .button { @include radius(0); }
+    &:first-child,
+    &:first-child > a,
+    &:first-child > button,
+    &:first-child > .button {
+      @if $orientation == vertical {
+        @include side-radius(top, $radius);
+      }
+      @else {
+        @include side-radius($default-float, $radius);
+      }
+    }
+    &:last-child,
+    &:last-child > a,
+    &:last-child > button,
+    &:last-child > .button {
+      @if $orientation == vertical {
+        @include side-radius(bottom, $radius);
+      }
+      @else {
+        @include side-radius($opposite-direction, $radius);
+      }
+    }
+  }
+
+  // We use this to make the buttons even width across their container
+  @if $even {
+    width: percentage((100/$even) / 100);
+    button, .button { width: 100%; }
+  }
+}
+
+@include exports("button-group") {
+  @if $include-html-button-classes {
+    .button-group { @include button-group-container;
+
+      @for $i from 2 through 8 {
+        &.even-#{$i} li { @include button-group-style($even:$i, $float:null); }
+      }
+
+      > li { @include button-group-style(); }
+
+      &.stack {
+        > li { @include button-group-style($orientation:vertical); float: none; }
+      }
+
+      &.stack-for-small {
+        > li {
+          @include button-group-style($orientation:horizontal);
+          @media #{$small-only} {
+            @include button-group-style($orientation:vertical);
+            width: 100%;
+          }
+        }
+      }
+
+      &.radius > * { @include button-group-style($radius:$button-radius, $float:null); }
+      &.radius.stack > * { @include button-group-style($radius:$button-radius, $float:null, $orientation:vertical); }
+      &.radius.stack-for-small > * {
+        @media #{$medium-up} {
+          @include button-group-style($radius:$button-radius, $orientation:horizontal);
+        }
+        @media #{$small-only} {
+          @include button-group-style($radius:$button-radius, $orientation:vertical);
+        }
+      }
+
+      &.round > * { @include button-group-style($radius:$button-round, $float:null); }
+      &.round.stack > * { @include button-group-style($radius:$button-med, $float:null, $orientation:vertical); }
+      &.round.stack-for-small > * {
+        @media #{$medium-up} {
+          @include button-group-style($radius:$button-round, $orientation:horizontal);
+        }
+        @media #{$small-only} {
+          @include button-group-style($radius:$button-med, $orientation:vertical);
+        }
+      }
+    }
+
+    .button-bar {
+      @include clearfix;
+      .button-group { @include button-group-container($styles:false, $float:true); }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_buttons.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_buttons.scss
@@ -1,0 +1,261 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-button-classes: $include-html-classes !default;
+
+// We use these to build padding for buttons.
+$button-tny: rem-calc(10) !default;
+$button-sml: rem-calc(14) !default;
+$button-med: rem-calc(16) !default;
+$button-lrg: rem-calc(18) !default;
+
+// We use this to control the display property.
+$button-display: inline-block !default;
+$button-margin-bottom: rem-calc(20) !default;
+
+// We use these to control button text styles.
+$button-font-family: $body-font-family !default;
+$button-font-color: $white !default;
+$button-font-color-alt: $oil !default;
+$button-font-tny: rem-calc(11) !default;
+$button-font-sml: rem-calc(13) !default;
+$button-font-med: rem-calc(16) !default;
+$button-font-lrg: rem-calc(20) !default;
+$button-font-weight: $font-weight-normal !default;
+$button-font-align: center !default;
+
+// We use these to control various hover effects.
+$button-function-factor: -20% !default;
+
+// We use these to control button border styles.
+$button-border-width: 0 !default;
+$button-border-style: solid !default;
+$button-bg-color: $primary-color !default;
+$button-bg-hover: scale-color($button-bg-color, $lightness: $button-function-factor) !default;
+$button-border-color: $button-bg-hover !default;
+$secondary-button-bg-color: $secondary-color !default;
+$secondary-button-bg-hover: scale-color($secondary-color, $lightness: $button-function-factor) !default;
+$secondary-button-border-color: $secondary-button-bg-hover !default;
+$success-button-bg-color: $success-color !default;
+$success-button-bg-hover: scale-color($success-color, $lightness: $button-function-factor) !default;
+$success-button-border-color: $success-button-bg-hover !default;
+$alert-button-bg-color: $alert-color !default;
+$alert-button-bg-hover: scale-color($alert-color, $lightness: $button-function-factor) !default;
+$alert-button-border-color: $alert-button-bg-hover !default;
+$warning-button-bg-color: $warning-color !default;
+$warning-button-bg-hover: scale-color($warning-color, $lightness: $button-function-factor) !default;
+$warning-button-border-color: $warning-button-bg-hover !default;
+$info-button-bg-color: $info-color !default;
+$info-button-bg-hover: scale-color($info-color, $lightness: $button-function-factor) !default;
+$info-button-border-color: $info-button-bg-hover !default;
+
+// We use this to set the default radius used throughout the core.
+$button-radius: $global-radius !default;
+$button-round: $global-rounded !default;
+
+// We use this to set default opacity and cursor for disabled buttons.
+$button-disabled-opacity: .7 !default;
+$button-disabled-cursor: $cursor-default-value !default;
+
+
+//
+// @MIXIN
+//
+// We use this mixin to create a default button base.
+//
+// $style - Sets base styles. Can be set to false. Default: true.
+// $display - Used to control display property. Default: $button-display || inline-block
+
+@mixin button-base($style:true, $display:$button-display) {
+  @if $style {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    border-radius:0;
+    border-style: $button-border-style;
+    border-width: $button-border-width;
+    cursor: $cursor-pointer-value;
+    font-family: $button-font-family;
+    font-weight: $button-font-weight;
+    line-height: normal;
+    margin: 0 0 $button-margin-bottom;
+    position: relative;
+    text-align: $button-font-align;
+    text-decoration: none;
+  }
+  @if $display { display: $display; }
+}
+
+// @MIXIN
+//
+// We use this mixin to add button size styles
+//
+// $padding - Used to build padding for buttons Default: $button-med ||= rem-calc(12)
+// $full-width - We can set $full-width:true to remove side padding extend width - Default: false
+
+@mixin button-size($padding:$button-med, $full-width:false) {
+
+  // We control which padding styles come through,
+  // these can be turned off by setting $padding:false
+  @if $padding {
+    padding: $padding ($padding * 2) ($padding + rem-calc(1)) ($padding * 2);
+    // We control the font-size based on mixin input.
+    @if      $padding == $button-med { font-size: $button-font-med; }
+    @else if $padding == $button-tny { font-size: $button-font-tny; }
+    @else if $padding == $button-sml { font-size: $button-font-sml; }
+    @else if $padding == $button-lrg { font-size: $button-font-lrg; }
+  }
+
+  // We can set $full-width:true to remove side padding extend width.
+  @if $full-width {
+    // We still need to check if $padding is set.
+    @if $padding {
+      padding-bottom: $padding + rem-calc(1);
+      padding-top: $padding;
+    } @else if $padding == false {
+      padding-bottom:0;
+      padding-top:0;
+    }
+    padding-left: $button-med;
+    padding-right: $button-med;
+    width: 100%;
+  }
+}
+
+// @MIXIN
+//
+// we use this mixin to create the button hover and border colors
+
+// @MIXIN
+//
+// We use this mixin to add button color styles
+//
+// $bg - Background color. We can set $bg:false for a transparent background. Default: $primary-color.
+// $radius - If true, set to button radius which is $button-radius || explicitly set radius amount in px (ex. $radius:10px). Default: false
+// $disabled - We can set $disabled:true to create a disabled transparent button. Default: false
+// $bg-hover - Button Hover Background Color. Default: $button-bg-hover
+// $border-color - Button Border Color. Default: $button-border-color
+@mixin button-style($bg:$button-bg-color, $radius:false, $disabled:false, $bg-hover:null, $border-color:null) {
+
+  // We control which background styles are used,
+  // these can be removed by setting $bg:false
+  @if $bg {
+
+    @if $bg-hover == null {
+      $bg-hover: if($bg == $button-bg-color, $button-bg-hover, scale-color($bg, $lightness: $button-function-factor));
+    }
+
+    @if $border-color == null {
+      $border-color: if($bg == $button-bg-color, $button-border-color, scale-color($bg, $lightness: $button-function-factor));
+    }
+
+    // This find the lightness percentage of the background color.
+    $bg-lightness: lightness($bg);
+    $bg-hover-lightness: lightness($bg-hover);
+
+    background-color: $bg;
+    border-color: $border-color;
+    &:hover,
+    &:focus { background-color: $bg-hover; }
+
+    // We control the text color for you based on the background color.
+    color: if($bg-lightness > 70%, $button-font-color-alt, $button-font-color);
+
+    &:hover,
+    &:focus {
+      color: if($bg-hover-lightness > 70%, $button-font-color-alt, $button-font-color);
+    }
+  }
+
+  // We can set $disabled:true to create a disabled transparent button.
+  @if $disabled {
+    box-shadow: none;
+    cursor: $button-disabled-cursor;
+    opacity: $button-disabled-opacity;
+    &:hover,
+    &:focus { background-color: $bg; }
+  }
+
+  // We can control how much button radius is used.
+  @if $radius == true { @include radius($button-radius); }
+  @else if $radius { @include radius($radius); }
+
+}
+
+// @MIXIN
+//
+// We use this to quickly create buttons with a single mixin. As @jaredhardy puts it, "the kitchen sink mixin"
+//
+// $padding - Used to build padding for buttons Default: $button-med ||= rem-calc(12)
+// $bg - Primary color set in settings file. Default: $button-bg.
+// $radius - If true, set to button radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default:false.
+// $full-width - We can set $full-width:true to remove side padding extend width. Default:false.
+// $disabled - We can set $disabled:true to create a disabled transparent button. Default:false.
+// $is-prefix - Not used? Default:false.
+// $bg-hover - Button Hover Color - Default null - see button-style mixin
+// $border-color - Button Border Color - Default null - see button-style mixin
+// $transition - We can control whether or not to include the background-color transition property - Default:true.
+@mixin button($padding:$button-med, $bg:$button-bg-color, $radius:false, $full-width:false, $disabled:false, $is-prefix:false, $bg-hover:null, $border-color:null, $transition: true) {
+  @include button-base;
+  @include button-size($padding, $full-width);
+  @include button-style($bg, $radius, $disabled, $bg-hover, $border-color);
+
+  @if $transition {
+    @include single-transition(background-color);
+  }
+}
+
+
+@include exports("button") {
+  @if $include-html-button-classes {
+
+    // Default styles applied outside of media query
+    button, .button {
+      @include button-base;
+      @include button-size;
+      @include button-style;
+
+      @include single-transition(background-color);
+
+      &.secondary { @include button-style($bg:$secondary-button-bg-color, $bg-hover:$secondary-button-bg-hover, $border-color:$secondary-button-border-color); }
+      &.success   { @include button-style($bg:$success-button-bg-color, $bg-hover:$success-button-bg-hover, $border-color:$success-button-border-color); }
+      &.alert     { @include button-style($bg:$alert-button-bg-color, $bg-hover:$alert-button-bg-hover, $border-color:$alert-button-border-color); }
+      &.warning   { @include button-style($bg:$warning-button-bg-color, $bg-hover:$warning-button-bg-hover, $border-color:$warning-button-border-color); }
+      &.info      { @include button-style($bg:$info-button-bg-color, $bg-hover:$info-button-bg-hover, $border-color:$info-button-border-color); }
+
+      &.large  { @include button-size($padding:$button-lrg); }
+      &.small  { @include button-size($padding:$button-sml); }
+      &.tiny   { @include button-size($padding:$button-tny); }
+      &.expand { @include button-size($full-width:true); }
+
+      &.left-align  { text-align: left; text-indent: rem-calc(12); }
+      &.right-align { text-align: right; padding-right: rem-calc(12); }
+
+      &.radius { @include button-style($bg:false, $radius:true); }
+      &.round  { @include button-style($bg:false, $radius:$button-round); }
+
+      &.disabled, &[disabled] { @include button-style($bg:$button-bg-color, $disabled:true, $bg-hover:$button-bg-hover, $border-color:$button-border-color);
+        &.secondary { @include button-style($bg:$secondary-button-bg-color, $disabled:true, $bg-hover:$secondary-button-bg-hover, $border-color:$secondary-button-border-color); }
+        &.success { @include button-style($bg:$success-button-bg-color, $disabled:true, $bg-hover:$success-button-bg-hover, $border-color:$success-button-border-color); }
+        &.alert { @include button-style($bg:$alert-button-bg-color, $disabled:true, $bg-hover:$alert-button-bg-hover, $border-color:$alert-button-border-color); }
+        &.warning { @include button-style($bg:$warning-button-bg-color, $disabled:true, $bg-hover:$warning-button-bg-hover, $border-color:$warning-button-border-color); }
+        &.info { @include button-style($bg:$info-button-bg-color, $disabled:true, $bg-hover:$info-button-bg-hover, $border-color:$info-button-border-color); }
+      }
+    }
+
+    //firefox 2px fix
+    button::-moz-focus-inner {border:0; padding:0;}
+
+    @media #{$medium-up} {
+      button, .button {
+        @include button-base($style:false, $display:inline-block);
+        @include button-size($padding:false, $full-width:false);
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_clearing.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_clearing.scss
@@ -1,0 +1,260 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-clearing-classes: $include-html-classes !default;
+
+// We use these to set the background colors for parts of Clearing.
+$clearing-bg: $oil !default;
+$clearing-caption-bg: $clearing-bg !default;
+$clearing-carousel-bg: rgba(51,51,51,0.8) !default;
+$clearing-img-bg: $clearing-bg !default;
+
+// We use these to style the close button
+$clearing-close-color: $iron !default;
+$clearing-close-size: 30px !default;
+
+// We use these to style the arrows
+$clearing-arrow-size: 12px !default;
+$clearing-arrow-color: $clearing-close-color !default;
+
+// We use these to style captions
+$clearing-caption-font-color: $iron !default;
+$clearing-caption-font-size: .875em !default;
+$clearing-caption-padding: 10px 30px 20px !default;
+
+// We use these to make the image and carousel height and style
+$clearing-active-img-height: 85% !default;
+$clearing-carousel-height: 120px !default;
+$clearing-carousel-thumb-width: 120px !default;
+$clearing-carousel-thumb-active-border: 1px solid rgb(255,255,255) !default;
+
+@include exports("clearing") {
+  @if $include-html-clearing-classes {
+    // We decided to not create a mixin for Clearing because it relies
+    // on predefined classes and structure to work properly.
+    // The variables above should give enough control.
+
+    /* Clearing Styles */
+    .clearing-thumbs, #{data('clearing')} {
+      @include clearfix;
+      list-style: none;
+      margin-#{$default-float}: 0;
+      margin-bottom: 0;
+
+      li {
+        float: $default-float;
+        margin-#{$opposite-direction}: 10px;
+      }
+
+      &[class*="block-grid-"] li {
+        margin-#{$opposite-direction}: 0;
+      }
+    }
+
+    .clearing-blackout {
+      background: $clearing-bg;
+      height: 100%;
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 998;
+      #{$default-float}: 0;
+
+      .clearing-close { display: block; }
+    }
+
+    .clearing-container {
+      height: 100%;
+      margin: 0;
+      overflow: hidden;
+      position: relative;
+      z-index: 998;
+    }
+
+    .clearing-touch-label {
+      color: $base;
+      font-size: .6em;
+      left: 50%;
+      position: absolute;
+      top: 50%;
+    }
+
+    .visible-img {
+      height: 95%;
+      position: relative;
+
+      img {
+        position: absolute;
+        #{$default-float}: 50%;
+        top: 50%;
+        @if $default-float == left {
+          -webkit-transform: translateY(-50%) translateX(-50%);
+          -moz-transform: translateY(-50%) translateX(-50%);
+          -ms-transform: translateY(-50%) translateX(-50%);
+          -o-transform: translateY(-50%) translateX(-50%);
+          transform: translateY(-50%) translateX(-50%);
+        }
+        @else {
+          -webkit-transform: translateY(-50%) translateX(50%);
+          -moz-transform: translateY(-50%) translateX(50%);
+          -ms-transform: translateY(-50%) translateX(50%);
+          -o-transform: translateY(-50%) translateX(50%);
+          transform: translateY(-50%) translateX(50%);
+        };
+        max-height: 100%;
+        max-width: 100%;
+      }
+    }
+
+    .clearing-caption {
+      background: $clearing-caption-bg;
+      bottom: 0;
+      color: $clearing-caption-font-color;
+      font-size: $clearing-caption-font-size;
+      line-height: 1.3;
+      margin-bottom: 0;
+      padding: $clearing-caption-padding;
+      position: absolute;
+      text-align: center;
+      width: 100%;
+      #{$default-float}: 0;
+    }
+
+    .clearing-close {
+      color: $clearing-close-color;
+      display: none;
+      font-size: $clearing-close-size;
+      line-height: 1;
+      padding-#{$default-float}: 20px;
+      padding-top: 10px;
+      z-index: 999;
+
+      &:hover,
+      &:focus { color: $iron; }
+    }
+
+    .clearing-assembled .clearing-container { height: 100%;
+      .carousel > ul { display: none; }
+    }
+
+    // If you want to show a lightbox, but only have a single image come through as the thumbnail
+    .clearing-feature li {
+      display: none;
+      &.clearing-featured-img {
+        display: block;
+      }
+    }
+
+    // Large screen overrides
+    @media #{$medium-up} {
+      .clearing-main-prev,
+      .clearing-main-next {
+        height: 100%;
+        position: absolute;
+        top: 0;
+        width: 40px;
+        > span {
+          border: solid $clearing-arrow-size;
+          display: block;
+          height: 0;
+          position: absolute;
+          top: 50%;
+          width: 0;
+          &:hover { opacity: .8; }
+        }
+      }
+      .clearing-main-prev {
+        #{$default-float}: 0;
+        > span {
+          #{$default-float}: 5px;
+          border-color: transparent;
+          border-#{$opposite-direction}-color: $clearing-arrow-color;
+        }
+      }
+      .clearing-main-next {
+        #{$opposite-direction}: 0;
+        > span {
+          border-color: transparent;
+          border-#{$default-float}-color: $clearing-arrow-color;
+        }
+      }
+
+      .clearing-main-prev.disabled,
+      .clearing-main-next.disabled { opacity: .3; }
+
+      .clearing-assembled .clearing-container {
+
+        .carousel {
+          background: $clearing-carousel-bg;
+          height: $clearing-carousel-height;
+          margin-top: 10px;
+          text-align: center;
+
+          > ul {
+            display: inline-block;
+            z-index: 999;
+            height: 100%;
+            position: relative;
+            float: none;
+
+            li {
+              clear: none;
+              cursor: $cursor-pointer-value;
+              display: block;
+              float: $default-float;
+              margin-#{$opposite-direction}: 0;
+              min-height: inherit;
+              opacity: .4;
+              overflow: hidden;
+              padding: 0;
+              position: relative;
+              width: $clearing-carousel-thumb-width;
+
+              &.fix-height {
+                img {
+                  height: 100%;
+                  max-width: none;
+                }
+              }
+
+              a.th {
+                border: none;
+                box-shadow: none;
+                display: block;
+              }
+
+              img {
+                cursor: $cursor-pointer-value !important;
+                width: 100% !important;
+              }
+
+              &.visible { opacity: 1; }
+              &:hover { opacity: .8; }
+            }
+          }
+        }
+
+        .visible-img {
+          background: $clearing-img-bg;
+          height: $clearing-active-img-height;
+          overflow: hidden;
+        }
+      }
+
+      .clearing-close {
+        padding-#{$default-float}: 0;
+        padding-top: 0;
+        position: absolute;
+        top: 10px;
+        #{$opposite-direction}: 20px;
+      }
+    }
+
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_dropdown-buttons.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_dropdown-buttons.scss
@@ -1,0 +1,130 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-button-classes: $include-html-classes !default;
+
+// We use these to set the color of the pip in dropdown buttons
+$dropdown-button-pip-color: $white !default;
+$dropdown-button-pip-color-alt: $oil !default;
+
+// We use these to set the size of the pip in dropdown buttons
+$button-pip-tny: rem-calc(6) !default;
+$button-pip-sml: rem-calc(7) !default;
+$button-pip-med: rem-calc(9) !default;
+$button-pip-lrg: rem-calc(11) !default;
+
+// We use these to style tiny dropdown buttons
+$dropdown-button-padding-tny: $button-pip-tny * 7 !default;
+$dropdown-button-pip-size-tny: $button-pip-tny !default;
+$dropdown-button-pip-opposite-tny: $button-pip-tny * 3 !default;
+$dropdown-button-pip-top-tny: (-$button-pip-tny / 2) + rem-calc(1) !default;
+
+// We use these to style small dropdown buttons
+$dropdown-button-padding-sml: $button-pip-sml * 7 !default;
+$dropdown-button-pip-size-sml: $button-pip-sml !default;
+$dropdown-button-pip-opposite-sml: $button-pip-sml * 3 !default;
+$dropdown-button-pip-top-sml: (-$button-pip-sml / 2) + rem-calc(1) !default;
+
+// We use these to style medium dropdown buttons
+$dropdown-button-padding-med: $button-pip-med * 6 + rem-calc(3) !default;
+$dropdown-button-pip-size-med: $button-pip-med - rem-calc(3) !default;
+$dropdown-button-pip-opposite-med: $button-pip-med * 2.5 !default;
+$dropdown-button-pip-top-med: (-$button-pip-med / 2) + rem-calc(2) !default;
+
+// We use these to style large dropdown buttons
+$dropdown-button-padding-lrg: $button-pip-lrg * 5 + rem-calc(3) !default;
+$dropdown-button-pip-size-lrg: $button-pip-lrg - rem-calc(6) !default;
+$dropdown-button-pip-opposite-lrg: $button-pip-lrg * 2.5 !default;
+$dropdown-button-pip-top-lrg: (-$button-pip-lrg / 2) + rem-calc(3) !default;
+
+// @mixins
+//
+// Dropdown Button Mixin
+//
+// We use this mixin to build off of the button mixin and add dropdown button styles
+//
+// $padding - Determines the size of button you're working with. Default: medium. Options [tiny, small, medium, large]
+// $pip-color - Color of the little triangle that points to the dropdown. Default: $white.
+// $base-style - Add in base-styles. This can be set to false. Default:true
+
+@mixin dropdown-button($padding:medium, $pip-color:$dropdown-button-pip-color, $base-style:true) {
+
+  // We add in base styles, but they can be negated by setting to 'false'.
+  @if $base-style {
+    position: relative;
+
+    // This creates the base styles for the triangle pip
+    &::after {
+      border-color: $dropdown-button-pip-color transparent transparent transparent;
+      border-style: solid;
+      content: "";
+      display: block;
+      height: 0;
+      position: absolute;
+      top: 50%;
+      width: 0;
+    }
+  }
+
+  // If we're dealing with tiny buttons, use these styles
+  @if $padding == tiny {
+    padding-#{$opposite-direction}: $dropdown-button-padding-tny;
+    &:after {
+      border-width: $dropdown-button-pip-size-tny;
+      #{$opposite-direction}: $dropdown-button-pip-opposite-tny;
+      margin-top: $dropdown-button-pip-top-tny;
+    }
+  }
+
+  // If we're dealing with small buttons, use these styles
+  @if $padding == small {
+    padding-#{$opposite-direction}: $dropdown-button-padding-sml;
+    &::after {
+      border-width: $dropdown-button-pip-size-sml;
+      #{$opposite-direction}: $dropdown-button-pip-opposite-sml;
+      margin-top: $dropdown-button-pip-top-sml;
+    }
+  }
+
+  // If we're dealing with default (medium) buttons, use these styles
+  @if $padding == medium {
+    padding-#{$opposite-direction}: $dropdown-button-padding-med;
+    &::after {
+      border-width: $dropdown-button-pip-size-med;
+      #{$opposite-direction}: $dropdown-button-pip-opposite-med;
+      margin-top: $dropdown-button-pip-top-med;
+    }
+  }
+
+  // If we're dealing with large buttons, use these styles
+  @if $padding == large {
+    padding-#{$opposite-direction}: $dropdown-button-padding-lrg;
+    &::after {
+      border-width: $dropdown-button-pip-size-lrg;
+      #{$opposite-direction}: $dropdown-button-pip-opposite-lrg;
+      margin-top: $dropdown-button-pip-top-lrg;
+    }
+  }
+
+  // We can control the pip color. We didn't use logic in this case, just set it and forget it.
+  @if $pip-color {
+    &::after { border-color: $pip-color transparent transparent transparent; }
+  }
+}
+
+@include exports("dropdown-button") {
+  @if $include-html-button-classes {
+    .dropdown.button, button.dropdown { @include dropdown-button;
+      &.tiny { @include dropdown-button(tiny, $base-style:false); }
+      &.small { @include dropdown-button(small, $base-style:false); }
+      &.large { @include dropdown-button(large, $base-style:false); }
+      &.secondary:after { border-color: $dropdown-button-pip-color-alt transparent transparent transparent; }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_dropdown.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_dropdown.scss
@@ -1,0 +1,269 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-dropdown-classes: $include-html-classes !default;
+
+// We use these to controls height and width styles.
+$f-dropdown-max-width: 200px !default;
+$f-dropdown-height: auto !default;
+$f-dropdown-max-height: none !default;
+
+// Used for bottom position
+$f-dropdown-margin-top: 2px !default;
+
+// Used for right position
+$f-dropdown-margin-left: $f-dropdown-margin-top !default;
+
+// Used for left position
+$f-dropdown-margin-right: $f-dropdown-margin-top !default;
+
+// Used for top position
+$f-dropdown-margin-bottom: $f-dropdown-margin-top !default;
+
+// We use this to control the background color
+$f-dropdown-bg: $white !default;
+
+// We use this to set the border styles for dropdowns.
+$f-dropdown-border-style: solid !default;
+$f-dropdown-border-width: 1px !default;
+$f-dropdown-border-color: scale-color($white, $lightness: -20%) !default;
+
+// We use these to style the triangle pip.
+$f-dropdown-triangle-size: 6px !default;
+$f-dropdown-triangle-color: $white !default;
+$f-dropdown-triangle-side-offset: 10px !default;
+
+// We use these to control styles for the list elements.
+$f-dropdown-list-style: none !default;
+$f-dropdown-font-color: $charcoal !default;
+$f-dropdown-font-size: rem-calc(14) !default;
+$f-dropdown-list-padding: rem-calc(5, 10) !default;
+$f-dropdown-line-height: rem-calc(18) !default;
+$f-dropdown-list-hover-bg: $smoke !default;
+$dropdown-mobile-default-float: 0 !default;
+
+// We use this to control the styles for when the dropdown has custom content.
+$f-dropdown-content-padding: rem-calc(20) !default;
+
+// Default radius for dropdown.
+$f-dropdown-radius: $global-radius !default;
+
+//
+// @mixins
+//
+//
+// NOTE: Make default max-width change between list and content types. Can add more width with classes, maybe .small, .medium, .large, etc.;
+// We use this to style the dropdown container element.
+// $content-list - Sets list-style. Default: list. Options: [list, content]
+// $triangle - Sets if dropdown has triangle. Default:true.
+// $max-width - Default: $f-dropdown-max-width || 200px.
+@mixin dropdown-container($content:list, $triangle:true, $max-width:$f-dropdown-max-width) {
+  display: none;
+  left: -9999px;
+  list-style: $f-dropdown-list-style;
+  margin-#{$default-float}: 0;
+  position: absolute;
+
+  &.open {
+    display: block;
+  }
+
+  > *:first-child { margin-top: 0; }
+  > *:last-child { margin-bottom: 0; }
+
+  @if $content == list {
+    background: $f-dropdown-bg;
+    border: $f-dropdown-border-style $f-dropdown-border-width $f-dropdown-border-color;
+    font-size: $f-dropdown-font-size;
+    height: $f-dropdown-height;
+    max-height: $f-dropdown-max-height;
+    width: 100%;
+    z-index: 89;
+  }
+  @else if $content == content {
+    background: $f-dropdown-bg;
+    border: $f-dropdown-border-style $f-dropdown-border-width $f-dropdown-border-color;
+    font-size: $f-dropdown-font-size;
+    height: $f-dropdown-height;
+    max-height: $f-dropdown-max-height;
+    padding: $f-dropdown-content-padding;
+    width: 100%;
+    z-index: 89;
+  }
+
+  @if $triangle == bottom {
+    margin-top: $f-dropdown-margin-top;
+
+    @if $f-dropdown-triangle-size != 0px {
+
+      &:before {
+        @include css-triangle($f-dropdown-triangle-size, $f-dropdown-triangle-color, bottom);
+        position: absolute;
+        top: -($f-dropdown-triangle-size * 2);
+        #{$default-float}: $f-dropdown-triangle-side-offset;
+        z-index: 89;
+      }
+      &:after {
+        @include css-triangle($f-dropdown-triangle-size + 1, $f-dropdown-border-color, bottom);
+        position: absolute;
+        top: -(($f-dropdown-triangle-size + 1) * 2);
+        #{$default-float}: $f-dropdown-triangle-side-offset - 1;
+        z-index: 88;
+      }
+
+      &.right:before {
+        #{$default-float}: auto;
+        #{$opposite-direction}: $f-dropdown-triangle-side-offset;
+      }
+      &.right:after {
+        #{$default-float}: auto;
+        #{$opposite-direction}: $f-dropdown-triangle-side-offset - 1;
+      }
+    }
+  }
+
+  @if $triangle == $default-float {
+    margin-top: 0;
+    margin-#{$default-float}: $f-dropdown-margin-right;
+
+    &:before {
+      @include css-triangle($f-dropdown-triangle-size, $f-dropdown-triangle-color, #{$opposite-direction});
+      position: absolute;
+      top: $f-dropdown-triangle-side-offset;
+      #{$default-float}: -($f-dropdown-triangle-size * 2);
+      z-index: 89;
+    }
+    &:after {
+      @include css-triangle($f-dropdown-triangle-size + 1, $f-dropdown-border-color, #{$opposite-direction});
+      position: absolute;
+      top: $f-dropdown-triangle-side-offset - 1;
+      #{$default-float}: -($f-dropdown-triangle-size * 2) - 2;
+      z-index: 88;
+    }
+
+  }
+
+  @if $triangle == $opposite-direction {
+    margin-top: 0;
+    margin-#{$default-float}: -$f-dropdown-margin-right;
+
+    &:before {
+      @include css-triangle($f-dropdown-triangle-size, $f-dropdown-triangle-color, #{$default-float});
+      position: absolute;
+      top: $f-dropdown-triangle-side-offset;
+      #{$opposite-direction}: -($f-dropdown-triangle-size * 2);
+      #{$default-float}: auto;
+      z-index: 89;
+    }
+    &:after {
+      @include css-triangle($f-dropdown-triangle-size + 1, $f-dropdown-border-color, #{$default-float});
+      position: absolute;
+      top: $f-dropdown-triangle-side-offset - 1;
+      #{$opposite-direction}: -($f-dropdown-triangle-size * 2) - 2;
+      #{$default-float}: auto;
+      z-index: 88;
+    }
+
+  }
+
+  @if $triangle == top {
+    margin-left: 0;
+    margin-top: -$f-dropdown-margin-bottom;
+
+    &:before {
+      @include css-triangle($f-dropdown-triangle-size, $f-dropdown-triangle-color, top);
+      bottom: -($f-dropdown-triangle-size * 2);
+      position: absolute;
+      top: auto;
+      #{$default-float}: $f-dropdown-triangle-side-offset;
+      #{$opposite-direction}: auto;
+      z-index: 89;
+    }
+    &:after {
+      @include css-triangle($f-dropdown-triangle-size + 1, $f-dropdown-border-color, top);
+      bottom: -($f-dropdown-triangle-size * 2) - 2;
+      position: absolute;
+      top: auto;
+      #{$default-float}: $f-dropdown-triangle-side-offset - 1;
+      #{$opposite-direction}: auto;
+      z-index: 88;
+    }
+
+  }
+
+  @if $max-width { max-width: $max-width; }
+  @else { max-width: $f-dropdown-max-width; }
+
+}
+
+// @MIXIN
+//
+// We use this to style the list elements or content inside the dropdown.
+
+@mixin dropdown-style {
+  cursor: $cursor-pointer-value;
+  font-size: $f-dropdown-font-size;
+  line-height: $f-dropdown-line-height;
+  margin: 0;
+
+  &:hover,
+  &:focus { background: $f-dropdown-list-hover-bg; }
+
+  a {
+    display: block;
+    padding: $f-dropdown-list-padding;
+    color: $f-dropdown-font-color;
+  }
+}
+
+@include exports("dropdown") {
+  @if $include-html-dropdown-classes {
+
+    /* Foundation Dropdowns */
+    .f-dropdown {
+      @include dropdown-container(list, bottom);
+
+      &.drop-#{$opposite-direction} {
+        @include dropdown-container(list, #{$default-float});
+      }
+
+      &.drop-#{$default-float} {
+        @include dropdown-container(list, #{$opposite-direction});
+      }
+
+      &.drop-top {
+        @include dropdown-container(list, top);
+      }
+      // max-width: none;
+
+      li { @include dropdown-style; }
+
+      // You can also put custom content in these dropdowns
+      &.content { @include dropdown-container(content, $triangle:false); }
+
+      // Radius of Dropdown
+      &.radius { @include radius($f-dropdown-radius); }
+
+      // Sizes
+      &.tiny    { max-width: 200px; }
+      &.small   { max-width: 300px; }
+      &.medium  { max-width: 500px; }
+      &.large   { max-width: 800px; }
+      &.mega    {
+        width:100%!important;
+        max-width:100%!important;
+
+        &.open{
+          left:0!important;
+        }
+      }
+    }
+
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_flex-video.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_flex-video.scss
@@ -1,0 +1,51 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-media-classes: $include-html-classes !default;
+
+// We use these to control video container padding and margins
+$flex-video-padding-top: rem-calc(25) !default;
+$flex-video-padding-bottom: 67.5% !default;
+$flex-video-margin-bottom: rem-calc(16) !default;
+
+// We use this to control widescreen bottom padding
+$flex-video-widescreen-padding-bottom: 56.34% !default;
+
+//
+// @mixins
+//
+
+@mixin flex-video-container {
+  height: 0;
+  margin-bottom: $flex-video-margin-bottom;
+  overflow: hidden;
+  padding-bottom: $flex-video-padding-bottom;
+  padding-top: $flex-video-padding-top;
+  position: relative;
+
+  &.widescreen { padding-bottom: $flex-video-widescreen-padding-bottom; }
+  &.vimeo { padding-top: 0; }
+
+  iframe,
+  object,
+  embed,
+  video {
+    height: 100%;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    #{$default-float}: 0;
+  }
+}
+
+@include exports("flex-video") {
+  @if $include-html-media-classes {
+    .flex-video { @include flex-video-container; }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_forms.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_forms.scss
@@ -1,0 +1,609 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+@import 'buttons';
+
+//
+// @variables
+//
+$include-html-form-classes: $include-html-classes !default;
+
+// We use this to set the base for lots of form spacing and positioning styles
+$form-spacing: rem-calc(16) !default;
+
+// We use these to style the labels in different ways
+$form-label-pointer: pointer !default;
+$form-label-font-size: rem-calc(14) !default;
+$form-label-font-weight: $font-weight-normal !default;
+$form-label-line-height: 1.5 !default;
+$form-label-font-color: scale-color($black, $lightness: 30%) !default;
+$form-label-small-transform: capitalize !default;
+$form-label-bottom-margin: 0 !default;
+$input-font-family: inherit !default;
+$input-font-color: rgba(0,0,0,0.75) !default;
+$input-placeholder-font-color: $steel !default;
+$input-font-size: rem-calc(14) !default;
+$input-bg-color: $white !default;
+$input-focus-bg-color: scale-color($white, $lightness: -2%) !default;
+$input-border-color: scale-color($white, $lightness: -20%) !default;
+$input-focus-border-color: scale-color($white, $lightness: -40%) !default;
+$input-border-style: solid !default;
+$input-border-width: 1px !default;
+$input-border-radius: $global-radius !default;
+$input-disabled-bg: $gainsboro !default;
+$input-disabled-cursor: $cursor-default-value !default;
+$input-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1) !default;
+$input-include-glowing-effect: false !default;
+
+// We use these to style the fieldset border and spacing.
+$fieldset-border-style: solid !default;
+$fieldset-border-width: 1px !default;
+$fieldset-border-color: $gainsboro !default;
+$fieldset-padding: rem-calc(20) !default;
+$fieldset-margin: rem-calc(18 0) !default;
+
+// We use these to style the legends when you use them
+$legend-bg: $white !default;
+$legend-font-weight: $font-weight-bold !default;
+$legend-padding: rem-calc(0 3) !default;
+
+// We use these to style the prefix and postfix input elements
+$input-prefix-bg: scale-color($white, $lightness: -5%) !default;
+$input-prefix-border-color: scale-color($white, $lightness: -20%) !default;
+$input-prefix-border-size: 1px !default;
+$input-prefix-border-type: solid !default;
+$input-prefix-overflow: visible !default;
+$input-prefix-font-color: $oil !default;
+$input-prefix-font-color-alt: $white !default;
+
+// We use this setting to turn on/off HTML5 number spinners (the up/down arrows)
+$input-number-spinners: true !default;
+
+// We use these to style the error states for inputs and labels
+$input-error-message-padding: rem-calc(6 9 9) !default;
+$input-error-message-top: -1px !default;
+$input-error-message-font-size: rem-calc(12) !default;
+$input-error-message-font-weight: $font-weight-normal !default;
+$input-error-message-font-style: italic !default;
+$input-error-message-font-color: $white !default;
+$input-error-message-bg-color: $alert-color !default;
+$input-error-message-font-color-alt: $oil !default;
+
+// We use this to style the glowing effect of inputs when focused
+$glowing-effect-fade-time: .45s !default;
+$glowing-effect-color: $input-focus-border-color !default;
+
+// We use this to style the transition when inputs are focused and when the glowing effect is disabled.
+$input-transition-fade-time: 0.15s !default;
+$input-transition-fade-timing-function: linear !default;
+
+// Select variables
+$select-bg-color: $ghost !default;
+$select-hover-bg-color: scale-color($select-bg-color, $lightness: -3%) !default;
+
+//
+// @MIXINS
+//
+
+// We use this mixin to give us form styles for rows inside of forms
+@mixin form-row-base {
+  .row { margin: 0 ((-$form-spacing) / 2);
+
+    .column,
+    .columns { padding: 0 ($form-spacing / 2); }
+
+    // Use this to collapse the margins of a form row
+    &.collapse { margin: 0;
+
+      .column,
+      .columns { padding: 0; }
+      input {
+        @include side-radius($opposite-direction, 0);
+      }
+
+    }
+  }
+  input.column,
+  input.columns,
+  textarea.column,
+  textarea.columns { padding-#{$default-float}: ($form-spacing / 2); }
+}
+
+// @MIXIN
+//
+// We use this mixin to give all basic form elements their style
+@mixin form-element {
+  background-color: $input-bg-color;
+  border: {
+    style: $input-border-style;
+    width: $input-border-width;
+    color: $input-border-color;
+  }
+  box-shadow: $input-box-shadow;
+  color: $input-font-color;
+  display: block;
+  font-family: $input-font-family;
+  font-size: $input-font-size;
+  height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
+  margin: 0 0 $form-spacing 0;
+  padding: $form-spacing / 2;
+  width: 100%;
+  @include box-sizing(border-box);
+  @if $input-include-glowing-effect {
+    @include block-glowing-effect(focus, $glowing-effect-fade-time, $glowing-effect-color);
+  }
+  // Basic focus styles
+  &:focus {
+    background: $input-focus-bg-color;
+    border-color: $input-focus-border-color;
+    outline: none;
+  }
+  // Disabled Styles
+  &:disabled {
+    background-color: $input-disabled-bg;
+    cursor: $input-disabled-cursor;
+  }
+
+  // Disabled background input background color
+  &[disabled],
+  &[readonly],
+  fieldset[disabled] & {
+    background-color: $input-disabled-bg;
+    cursor: $input-disabled-cursor;
+  }
+}
+
+// @MIXIN
+//
+// We use this mixin to create form labels
+//
+// $alignment - Alignment options. Default: false. Options: [right, inline, false]
+// $base-style - Control whether or not the base styles come through. Default: true.
+@mixin form-label($alignment:false, $base-style:true) {
+
+  // Control whether or not the base styles come through.
+  @if $base-style {
+    color: $form-label-font-color;
+    cursor: $form-label-pointer;
+    display: block;
+    font-size: $form-label-font-size;
+    font-weight: $form-label-font-weight;
+    line-height: $form-label-line-height;
+    margin-bottom: $form-label-bottom-margin;
+  }
+
+  // Alignment options
+  @if $alignment == right {
+    float: none !important;
+    text-align: right;
+  }
+  @else if $alignment == inline {
+    margin: 0 0 $form-spacing 0;
+    padding: $form-spacing / 2 + rem-calc($input-border-width) 0;
+  }
+}
+
+// We use this mixin to create postfix/prefix form Labels
+@mixin prefix-postfix-base {
+  border-style: $input-prefix-border-type;
+  border-width: $input-prefix-border-size;
+  display: block;
+  font-size: $form-label-font-size;
+  height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
+  line-height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
+  overflow: $input-prefix-overflow;
+  padding-bottom: 0;
+  padding-top: 0;
+  position: relative;
+  text-align: center;
+  width: 100%;
+  z-index: 2;
+}
+
+// @MIXIN
+//
+// We use this mixin to create prefix label styles
+// $bg - Default:$input-prefix-bg || scale-color($white, $lightness: -5%) !default;
+// $is-button - Toggle position settings if prefix is a button. Default:false
+//
+@mixin prefix($bg:$input-prefix-bg, $border:$input-prefix-border-color, $is-button:false) {
+
+  @if $bg {
+    $bg-lightness: lightness($bg);
+    background: $bg;
+    border-#{$opposite-direction}: none;
+
+    // Control the font color based on background brightness
+    @if $bg-lightness > 70% or $bg == yellow { color: $input-prefix-font-color; }
+    @else { color: $input-prefix-font-color-alt; }
+  }
+
+  @if $border {
+    border-color: $border;
+  }
+
+  @if $is-button {
+    border: none;
+    padding-#{$default-float}: 0;
+    padding-#{$opposite-direction}: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+    text-align: center;
+  }
+
+}
+
+// @MIXIN
+//
+// We use this mixin to create postfix label styles
+// $bg - Default:$input-prefix-bg || scale-color($white, $lightness: -5%) !default;
+// $is-button - Toggle position settings if prefix is a button. Default: false
+@mixin postfix($bg:$input-prefix-bg, $border-left-hidden:false, $border:$input-prefix-border-color, $is-button:false) {
+
+  @if $bg {
+    $bg-lightness: lightness($bg);
+    background: $bg;
+    @if $border-left-hidden {
+      border-#{$default-float}: none;
+    }
+
+    // Control the font color based on background brightness
+    @if $bg-lightness > 70%  or $bg == yellow { color: $input-prefix-font-color; }
+    @else { color: $input-prefix-font-color-alt; }
+  }
+
+  @if $border {
+    border-color: $border;
+  }
+
+  @if $is-button {
+    border: none;
+    padding-#{$default-float}: 0;
+    padding-#{$opposite-direction}: 0;
+    padding-bottom: 0;
+    padding-top: 0;
+    text-align: center;
+  }
+
+}
+
+// We use this mixin to style fieldsets
+@mixin fieldset {
+  border: $fieldset-border-width $fieldset-border-style $fieldset-border-color;
+  margin: $fieldset-margin;
+  padding: $fieldset-padding;
+
+  // and legend styles
+  legend {
+    background: $legend-bg;
+    font-weight: $legend-font-weight;
+    margin: 0;
+    margin-#{$default-float}: rem-calc(-3);
+    padding: $legend-padding;
+  }
+}
+
+// @MIXIN
+//
+// We use this mixin to control border and background color of error inputs
+// $color - Default: $alert-color (found in settings file)
+@mixin form-error-color($color:$alert-color) {
+  background-color: rgba($color, .1);
+  border-color: $color;
+
+  // Go back to normal on focus
+  &:focus {
+    background: $input-focus-bg-color;
+    border-color: $input-focus-border-color;
+  }
+}
+
+// @MIXIN
+//
+// We use this simple mixin to style labels for error inputs
+// $color - Default:$alert-color. Found in settings file
+@mixin form-label-error-color($color:$alert-color) { color: $color; }
+
+// @MIXIN
+//
+// We use this mixin to create error message styles
+// $bg - Default: $alert-color (Found in settings file)
+@mixin form-error-message($bg:$input-error-message-bg-color) {
+  display: block;
+  font-size: $input-error-message-font-size;
+  font-style: $input-error-message-font-style;
+  font-weight: $input-error-message-font-weight;
+  margin-bottom: $form-spacing;
+  margin-top: $input-error-message-top;
+  padding: $input-error-message-padding;
+
+  // We can control the text color based on the brightness of the background.
+  $bg-lightness: lightness($bg);
+  background: $bg;
+  @if $bg-lightness < 70% or $bg == yellow { color: $input-error-message-font-color; }
+  @else { color: $input-error-message-font-color-alt; }
+}
+
+// We use this mixin to style select elements
+@mixin form-select  {
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  background-color: $select-bg-color;
+  border-radius: 0;
+
+  // Hide the dropdown arrow shown in newer IE versions
+  &::-ms-expand {
+    display: none;
+  }
+
+  // The custom arrow has some fake horizontal padding so we can align it
+  // from the right side of the element without relying on CSS3
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMTJweCIgeT0iMHB4IiB3aWR0aD0iMjRweCIgaGVpZ2h0PSIzcHgiIHZpZXdCb3g9IjAgMCA2IDMiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMCAwIDYgMyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+PHBvbHlnb24gcG9pbnRzPSI1Ljk5MiwwIDIuOTkyLDMgLTAuMDA4LDAgIi8+PC9zdmc+);
+
+  // We can safely use leftmost and rightmost now
+  background-position: if($text-direction == 'rtl', 0%, 100%) center;
+
+  background-repeat: no-repeat;
+  border: {
+    style: $input-border-style;
+    width: $input-border-width;
+    color: $input-border-color;
+  }
+  color: $input-font-color;
+  font-family: $input-font-family;
+  font-size: $input-font-size;
+  line-height: normal;
+  padding: ($form-spacing / 2);
+  @include radius(0);
+  &.radius { @include radius($global-radius); }
+  &:hover {
+    background-color: $select-hover-bg-color;
+    border-color: $input-focus-border-color;
+  }
+  // Disabled Styles
+  &:disabled {
+    background-color: $input-disabled-bg;
+    cursor: $input-disabled-cursor;
+  }
+}
+
+// We use this mixin to turn on/off HTML5 number spinners
+@mixin html5number($browser, $on:true) {
+  @if $on==false {
+      @if $browser==webkit {
+        -webkit-appearance: none;
+        margin: 0;
+      } @else if $browser==moz {
+        -moz-appearance: textfield;
+      }
+  }
+}
+
+@include exports("form") {
+  @if $include-html-form-classes {
+    /* Standard Forms */
+    form { margin: 0 0 $form-spacing; }
+
+    /* Using forms within rows, we need to set some defaults */
+    form .row { @include form-row-base; }
+
+    /* Label Styles */
+    label { @include form-label;
+      &.right { @include form-label(right, false); }
+      &.inline { @include form-label(inline, false); }
+      /* Styles for required inputs */
+      small {
+        text-transform: $form-label-small-transform;
+        color: scale-color($form-label-font-color, $lightness: 15%);
+      }
+    }
+
+    /* Attach elements to the beginning or end of an input */
+    .prefix,
+    .postfix { @include prefix-postfix-base; }
+
+    /* Adjust padding, alignment and radius if pre/post element is a button */
+    .postfix.button { @include button-size(false, false); @include postfix(false, false, false, true); }
+    .prefix.button { @include button-size(false, false); @include prefix(false, false, true); }
+
+    .prefix.button.radius { @include radius(0); @include side-radius($default-float, $button-radius); }
+    .postfix.button.radius { @include radius(0); @include side-radius($opposite-direction, $button-radius); }
+    .prefix.button.round { @include radius(0); @include side-radius($default-float, $button-round); }
+    .postfix.button.round { @include radius(0); @include side-radius($opposite-direction, $button-round); }
+
+    /* Separate prefix and postfix styles when on span or label so buttons keep their own */
+    span.prefix, label.prefix { @include prefix(); }
+    span.postfix, label.postfix { @include postfix(); }
+
+    /* We use this to get basic styling on all basic form elements */
+    input:not([type]), #{text-inputs(all, 'input')} {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      border-radius: 0;
+      @include form-element;
+      @if $input-include-glowing-effect == false {
+        -webkit-transition: border-color $input-transition-fade-time $input-transition-fade-timing-function, background $input-transition-fade-time $input-transition-fade-timing-function;
+        -moz-transition: border-color $input-transition-fade-time $input-transition-fade-timing-function, background $input-transition-fade-time $input-transition-fade-timing-function;
+        -ms-transition: border-color $input-transition-fade-time $input-transition-fade-timing-function, background $input-transition-fade-time $input-transition-fade-timing-function;
+        -o-transition: border-color $input-transition-fade-time $input-transition-fade-timing-function, background $input-transition-fade-time $input-transition-fade-timing-function;
+        transition: border-color $input-transition-fade-time $input-transition-fade-timing-function, background $input-transition-fade-time $input-transition-fade-timing-function;
+      }
+      &.radius {
+        @include radius($input-border-radius);
+      }
+    }
+
+    form {
+      .row {
+        .prefix-radius.row.collapse {
+          input,
+          textarea,
+          select,
+          button { @include radius(0); @include side-radius($opposite-direction, $button-radius); }
+          .prefix { @include radius(0); @include side-radius($default-float, $button-radius); }
+        }
+        .postfix-radius.row.collapse {
+          input,
+          textarea,
+          select,
+          button { @include radius(0); @include side-radius($default-float, $button-radius); }
+          .postfix { @include radius(0); @include side-radius($opposite-direction, $button-radius); }
+        }
+        .prefix-round.row.collapse {
+          input,
+          textarea,
+          select,
+          button { @include radius(0); @include side-radius($opposite-direction, $button-round); }
+          .prefix { @include radius(0); @include side-radius($default-float, $button-round); }
+        }
+        .postfix-round.row.collapse {
+          input,
+          textarea,
+          select,
+          button { @include radius(0); @include side-radius($default-float, $button-round); }
+          .postfix { @include radius(0); @include side-radius($opposite-direction, $button-round); }
+        }
+      }
+    }
+
+    input[type="submit"] {
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      border-radius: 0;
+    }
+
+    /* Respect enforced amount of rows for textarea */
+    textarea[rows] {
+      height: auto;
+    }
+
+    /* Not allow resize out of parent */
+    textarea {
+      max-width: 100%;
+    }
+
+    // style placeholder text cross browser
+    ::-webkit-input-placeholder {
+      color: $input-placeholder-font-color;
+    }
+
+    :-moz-placeholder { /* Firefox 18- */
+       color: $input-placeholder-font-color;
+    }
+
+    ::-moz-placeholder {  /* Firefox 19+ */
+       color: $input-placeholder-font-color;
+    }
+
+    :-ms-input-placeholder {
+       color: $input-placeholder-font-color;
+    }
+
+
+    /* Add height value for select elements to match text input height */
+    select {
+      @include form-select;
+      height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
+      &[multiple] {
+        height: auto;
+      }
+    }
+
+    /* Adjust margin for form elements below */
+    input[type="file"],
+    input[type="checkbox"],
+    input[type="radio"],
+    select {
+      margin: 0 0 $form-spacing 0;
+    }
+
+    input[type="checkbox"] + label,
+    input[type="radio"] + label {
+      display: inline-block;
+      margin-#{$default-float}: $form-spacing * .5;
+      margin-#{$opposite-direction}: $form-spacing;
+      margin-bottom: 0;
+      vertical-align: baseline;
+    }
+
+    /* Normalize file input width */
+    input[type="file"] {
+      width:100%;
+    }
+
+    /* HTML5 Number spinners settings */
+    input[type=number] {
+      @include html5number(moz, $input-number-spinners)
+    }
+    input[type="number"]::-webkit-inner-spin-button,
+    input[type="number"]::-webkit-outer-spin-button {
+      @include html5number(webkit, $input-number-spinners);
+    }
+
+    /* We add basic fieldset styling */
+    fieldset {
+      @include fieldset;
+    }
+
+    /* Error Handling */
+
+    #{data('abide')} {
+      .error small.error, .error span.error, span.error, small.error {
+        @include form-error-message;
+      }
+      span.error, small.error { display: none; }
+    }
+
+    span.error, small.error {
+      @include form-error-message;
+    }
+
+    .error {
+      input,
+      textarea,
+      select {
+        margin-bottom: 0;
+      }
+
+      input[type="checkbox"],
+      input[type="radio"] {
+        margin-bottom: $form-spacing
+      }
+
+      label,
+      label.error {
+        @include form-label-error-color;
+      }
+
+      small.error {
+        @include form-error-message;
+      }
+
+      > label {
+        > small {
+          background: transparent;
+          color: scale-color($form-label-font-color, $lightness: 15%);
+          display: inline;
+          font-size: 60%;
+          font-style: normal;
+          margin: 0;
+          padding: 0;
+          text-transform: $form-label-small-transform;
+        }
+      }
+
+      span.error-message {
+        display: block;
+      }
+    }
+
+    input.error,
+    textarea.error,
+    select.error {
+      margin-bottom: 0;
+    }
+    label.error { @include form-label-error-color; }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_global.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_global.scss
@@ -1,0 +1,499 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import '../functions';
+//
+// Foundation Variables
+//
+
+// Data attribute namespace
+// styles get applied to [data-mysite-plugin], etc
+$namespace: false !default;
+
+// The default font-size is set to 100% of the browser style sheet (usually 16px)
+// for compatibility with browser-based text zoom or user-set defaults.
+
+// Since the typical default browser font-size is 16px, that makes the calculation for grid size.
+// If you want your base font-size to be different and not have it affect the grid breakpoints,
+// set $rem-base to $base-font-size and make sure $base-font-size is a px value.
+$base-font-size: 100% !default;
+
+// $base-line-height is 24px while $base-font-size is 16px
+$base-line-height: 1.5 !default;
+
+//
+// Global Foundation Mixins
+//
+
+// @mixins
+//
+// We use this to control border radius.
+// $radius - Default: $global-radius || 4px
+@mixin radius($radius:$global-radius) {
+  @if $radius {
+    border-radius: $radius;
+  }
+}
+
+// @mixins
+//
+// We use this to create equal side border radius on elements.
+// $side - Options: left, right, top, bottom
+@mixin side-radius($side, $radius:$global-radius) {
+  @if ($side == left or $side == right) {
+    -webkit-border-bottom-#{$side}-radius: $radius;
+    -webkit-border-top-#{$side}-radius: $radius;
+    border-bottom-#{$side}-radius: $radius;
+    border-top-#{$side}-radius: $radius;
+  } @else {
+    -webkit-#{$side}-left-radius: $radius;
+    -webkit-#{$side}-right-radius: $radius;
+    border-#{$side}-left-radius: $radius;
+    border-#{$side}-right-radius: $radius;
+  }
+}
+
+// @mixins
+//
+// We can control whether or not we have inset shadows edges.
+// $active - Default: true, Options: false
+@mixin inset-shadow($active:true) {
+  box-shadow: $shiny-edge-size $shiny-edge-color inset;
+
+  @if $active { &:active {
+    box-shadow: $shiny-edge-size $shiny-edge-active-color inset; } }
+}
+
+// @mixins
+//
+// We use this to add transitions to elements
+// $property - Default: all, Options: http://www.w3.org/TR/css3-transitions/#animatable-properties
+// $speed - Default: 300ms
+// $ease - Default:ease-out, Options: http://css-tricks.com/almanac/properties/t/transition-timing-function/
+@mixin single-transition($property:all, $speed:300ms, $ease:ease-out) {
+  transition: $property $speed $ease;
+}
+
+// @mixins
+//
+// We use this to add box-sizing across browser prefixes
+@mixin box-sizing($type:border-box) {
+  -webkit-box-sizing: $type; // Android < 2.3, iOS < 4
+     -moz-box-sizing: $type; // Firefox < 29
+          box-sizing: $type; // Chrome, IE 8+, Opera, Safari 5.1
+}
+
+// @mixins
+//
+// We use this to create isosceles triangles
+// $triangle-size - Used to set border-size. No default, set a px or em size.
+// $triangle-color - Used to set border-color which makes up triangle. No default
+// $triangle-direction - Used to determine which direction triangle points. Options: top, bottom, left, right
+@mixin css-triangle($triangle-size, $triangle-color, $triangle-direction) {
+  border: inset $triangle-size;
+  content: "";
+  display: block;
+  height: 0;
+  width: 0;
+  @if ($triangle-direction == top) {
+    border-color: $triangle-color transparent transparent transparent;
+    border-top-style: solid;
+  }
+  @if ($triangle-direction == bottom) {
+    border-color: transparent transparent $triangle-color transparent;
+    border-bottom-style: solid;
+  }
+  @if ($triangle-direction == left) {
+    border-color: transparent transparent transparent $triangle-color;
+    border-left-style: solid;
+  }
+  @if ($triangle-direction == right) {
+    border-color: transparent $triangle-color transparent transparent;
+    border-right-style: solid;
+  }
+}
+
+// @mixins
+//
+// We use this to create the icon with three lines aka the hamburger icon, the menu-icon or the navicon
+// $width - Width of hamburger icon in rem
+// $left - If false, icon will be centered horizontally || explicitly set value in rem
+// $top - If false, icon will be centered vertically || explicitly set value in rem
+// $thickness - thickness of lines in hamburger icon, set value in px
+// $gap - spacing between the lines in hamburger icon, set value in px
+// $color - icon color
+// $hover-color - icon color during hover
+// $offcanvas - Set to true of @include in offcanvas
+@mixin hamburger($width, $left, $top, $thickness, $gap, $color, $hover-color, $offcanvas) {
+  span::after {
+    content: "";
+    display: block;
+    height: 0;
+    position: absolute;
+
+    @if $offcanvas {
+      @if $top {
+        top: $top;
+      }
+      @else {
+        top: 50%;
+        margin-top: (-$width/2);
+      }
+      @if $left {
+        left: $left;
+      }
+      @else {
+        left: ($tabbar-menu-icon-width - $width)/2;
+      }
+    }
+    @else {
+      margin-top: -($width/2);
+      top: 50%;
+      #{$opposite-direction}: $topbar-link-padding;
+    }
+
+    box-shadow:
+      0 0 0 $thickness $color,
+      0 $gap + $thickness 0 $thickness $color,
+      0 (2 * $gap + 2*$thickness) 0 $thickness $color;
+    width: $width;
+  }
+  span:hover:after {
+    box-shadow:
+      0 0 0 $thickness $hover-color,
+      0 $gap + $thickness 0 $thickness $hover-color,
+      0 (2 * $gap + 2*$thickness) 0 $thickness $hover-color;
+  }
+}
+
+// We use this to do clear floats
+@mixin clearfix {
+  &:before, &:after { content: " "; display: table; }
+  &:after { clear: both; }
+}
+
+// @mixins
+//
+// We use this to add a glowing effect to block elements
+// $selector - Used for selector state. Default: focus, Options: hover, active, visited
+// $fade-time - Default: 300ms
+// $glowing-effect-color - Default: fade-out($primary-color, .25)
+@mixin block-glowing-effect($selector:focus, $fade-time:300ms, $glowing-effect-color:fade-out($primary-color, .25)) {
+  transition: box-shadow $fade-time, border-color $fade-time ease-in-out;
+
+  &:#{$selector} {
+    border-color: $glowing-effect-color;
+    box-shadow: 0 0 5px $glowing-effect-color;
+  }
+}
+
+// @mixins
+//
+// We use this to translate elements in 2D
+// $horizontal: Default: 0
+// $vertical: Default: 0
+@mixin translate2d($horizontal:0, $vertical:0) {
+  transform: translate($horizontal, $vertical)
+}
+
+// @mixins
+//
+// Makes an element visually hidden, but accessible.
+// @see http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
+@mixin element-invisible {
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute !important;
+  width: 1px;
+}
+
+// @mixins
+//
+// Turns off the element-invisible effect.
+@mixin element-invisible-off {
+  position: static !important;
+  height: auto;
+  width: auto;
+  overflow: visible;
+  clip: auto;
+}
+
+$white         : #FFFFFF !default;
+$ghost         : #FAFAFA !default;
+$snow          : #F9F9F9 !default;
+$vapor         : #F6F6F6 !default;
+$white-smoke   : #F5F5F5 !default;
+$silver        : #EFEFEF !default;
+$smoke         : #EEEEEE !default;
+$gainsboro     : #DDDDDD !default;
+$iron          : #CCCCCC !default;
+$base          : #AAAAAA !default;
+$aluminum      : #999999 !default;
+$jumbo         : #888888 !default;
+$monsoon       : #777777 !default;
+$steel         : #666666 !default;
+$charcoal      : #555555 !default;
+$tuatara       : #444444 !default;
+$oil           : #333333 !default;
+$jet           : #222222 !default;
+$black         : #000000 !default;
+
+// We use these as default colors throughout
+$primary-color: #008CBA !default;   // bondi-blue
+$secondary-color: #e7e7e7 !default; // white-lilac
+$alert-color: #f04124 !default;     // cinnabar
+$success-color: #43AC6A !default;   // sea-green
+$warning-color: #f08a24 !default;   // carrot
+$info-color: #a0d3e8 !default;      // cornflower
+
+// We use these to define default font stacks
+$font-family-sans-serif: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif !default;
+$font-family-serif: Georgia, Cambria, "Times New Roman", Times, serif !default;
+$font-family-monospace: Consolas, "Liberation Mono", Courier, monospace !default;
+
+// We use these to define default font weights
+$font-weight-normal: normal !default;
+$font-weight-bold: bold !default;
+
+// We use these to control various global styles
+$body-bg: #fff !default;
+$body-font-color: #222 !default;
+$body-font-family: $font-family-sans-serif !default;
+$body-font-weight: $font-weight-normal !default;
+$body-font-style: normal !default;
+
+// We use this to control font-smoothing
+$font-smoothing: antialiased !default;
+
+// We use these to control text direction settings
+$text-direction: ltr !default;
+$default-float: left !default;
+$opposite-direction: right !default;
+@if $text-direction == ltr {
+  $default-float: left;
+  $opposite-direction: right;
+} @else {
+  $default-float: right;
+  $opposite-direction: left;
+}
+
+// We use these to make sure border radius matches unless we want it different.
+$global-radius: 3px !default;
+$global-rounded: 1000px !default;
+
+// We use these to control inset shadow shiny edges and depressions.
+$shiny-edge-size: 0 1px 0 !default;
+$shiny-edge-color: rgba(#fff, .5) !default;
+$shiny-edge-active-color: rgba(#000, .2) !default;
+
+// We use this to control whether or not CSS classes come through in the gem files.
+$include-html-classes: true !default;
+$include-print-styles: true !default;
+$include-js-meta-styles: true !default; // Warning! Meta styles are a dependancy of the Javascript.
+$include-html-global-classes: $include-html-classes !default;
+
+$column-gutter: rem-calc(30) !default;
+
+// Media Query Ranges
+$small-breakpoint:  em-calc(640)  !default;
+$medium-breakpoint: em-calc(1024) !default;
+$large-breakpoint:  em-calc(1440) !default;
+$xlarge-breakpoint: em-calc(1920) !default;
+
+$small-range:   (0, $small-breakpoint) !default;
+$medium-range:  ($small-breakpoint  + em-calc(1), $medium-breakpoint) !default;
+$large-range:   ($medium-breakpoint + em-calc(1), $large-breakpoint)  !default;
+$xlarge-range:  ($large-breakpoint  + em-calc(1), $xlarge-breakpoint) !default;
+$xxlarge-range: ($xlarge-breakpoint + em-calc(1), em-calc(99999999)) !default;
+
+$screen: "only screen" !default;
+
+$landscape: "#{$screen} and (orientation: landscape)" !default;
+$portrait: "#{$screen} and (orientation: portrait)" !default;
+
+$small-up: $screen !default;
+$small-only: "#{$screen} and (max-width: #{upper-bound($small-range)})" !default;
+
+$medium-up: "#{$screen} and (min-width:#{lower-bound($medium-range)})" !default;
+$medium-only: "#{$screen} and (min-width:#{lower-bound($medium-range)}) and (max-width:#{upper-bound($medium-range)})" !default;
+
+$large-up: "#{$screen} and (min-width:#{lower-bound($large-range)})" !default;
+$large-only: "#{$screen} and (min-width:#{lower-bound($large-range)}) and (max-width:#{upper-bound($large-range)})" !default;
+
+$xlarge-up: "#{$screen} and (min-width:#{lower-bound($xlarge-range)})" !default;
+$xlarge-only: "#{$screen} and (min-width:#{lower-bound($xlarge-range)}) and (max-width:#{upper-bound($xlarge-range)})" !default;
+
+$xxlarge-up: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)})" !default;
+$xxlarge-only: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)}) and (max-width:#{upper-bound($xxlarge-range)})" !default;
+
+$retina: (
+  "#{$screen} and (-webkit-min-device-pixel-ratio: 2)",
+  "#{$screen} and (min--moz-device-pixel-ratio: 2)",
+  "#{$screen} and (-o-min-device-pixel-ratio: 2/1)",
+  "#{$screen} and (min-device-pixel-ratio: 2)",
+  "#{$screen} and (min-resolution: 192dpi)",
+  "#{$screen} and (min-resolution: 2dppx)"
+);
+
+// Legacy
+$small: $medium-up;
+$medium: $medium-up;
+$large: $large-up;
+
+
+//We use this as cursors values for enabling the option of having custom cursors in the whole site's stylesheet
+$cursor-auto-value: auto !default;
+$cursor-crosshair-value: crosshair !default;
+$cursor-default-value: default !default;
+$cursor-disabled-value: not-allowed !default;
+$cursor-pointer-value: pointer !default;
+$cursor-help-value: help !default;
+$cursor-text-value: text !default;
+
+
+@include exports("global") {
+
+  // Meta styles are a dependancy of the Javascript.
+  // Used to provide media query values for javascript components.
+  // Forward slash placed around everything to convince PhantomJS to read the value.
+
+  @if $include-js-meta-styles {
+
+    meta.foundation-version {
+      font-family: "/5.5.2/";
+    }
+
+    meta.foundation-mq-small {
+      font-family: "/" + unquote($small-up) + "/";
+      width: lower-bound($small-range);
+    }
+
+    meta.foundation-mq-small-only {
+      font-family: "/" + unquote($small-only) + "/";
+      width: lower-bound($small-range);
+    }
+
+    meta.foundation-mq-medium {
+      font-family: "/" + unquote($medium-up) + "/";
+      width: lower-bound($medium-range);
+    }
+
+    meta.foundation-mq-medium-only {
+      font-family: "/" + unquote($medium-only) + "/";
+      width: lower-bound($medium-range);
+    }
+
+    meta.foundation-mq-large {
+      font-family: "/" + unquote($large-up) + "/";
+      width: lower-bound($large-range);
+    }
+
+    meta.foundation-mq-large-only {
+      font-family: "/" + unquote($large-only) + "/";
+      width: lower-bound($large-range);
+    }
+
+    meta.foundation-mq-xlarge {
+      font-family: "/" + unquote($xlarge-up) + "/";
+      width: lower-bound($xlarge-range);
+    }
+
+    meta.foundation-mq-xlarge-only {
+      font-family: "/" + unquote($xlarge-only) + "/";
+      width: lower-bound($xlarge-range);
+    }
+
+    meta.foundation-mq-xxlarge {
+      font-family: "/" + unquote($xxlarge-up) + "/";
+      width: lower-bound($xxlarge-range);
+    }
+
+    meta.foundation-data-attribute-namespace {
+      font-family: #{$namespace};
+    }
+
+  }
+
+  @if $include-html-global-classes {
+
+    // Must be 100% for off canvas to work
+    html, body { height: 100%; }
+
+    // Set box-sizing globally to handle padding and border widths
+    *,
+    *:before,
+    *:after {
+      @include box-sizing(border-box);
+    }
+
+    html,
+    body { font-size: $base-font-size; }
+
+    // Default body styles
+    body {
+      background: $body-bg;
+      color: $body-font-color;
+      cursor: $cursor-auto-value;
+      font-family: $body-font-family;
+      font-style: $body-font-style;
+      font-weight: $body-font-weight;
+      line-height: $base-line-height; // Set to $base-line-height to take on browser default of 150%
+      margin: 0;
+      padding: 0;
+      position: relative;
+    }
+
+  a:hover { cursor: $cursor-pointer-value; }
+
+    // Grid Defaults to get images and embeds to work properly
+    img { max-width: 100%; height: auto; }
+
+    img { -ms-interpolation-mode: bicubic; }
+
+    #map_canvas,
+    .map_canvas,
+    .mqa-display {
+      img,
+      embed,
+      object { max-width: none !important;
+      }
+    }
+
+    // Miscellaneous useful HTML classes
+    .left { float: left !important; }
+    .right { float: right !important; }
+    .clearfix { @include clearfix; }
+
+    // Hide visually and from screen readers
+    .hide {
+      display: none;
+    }
+
+    // Hide visually and from screen readers, but maintain layout
+    .invisible { visibility: hidden; }
+
+    // Font smoothing
+    // Antialiased font smoothing works best for light text on a dark background.
+    // Apply to single elements instead of globally to body.
+    // Note this only applies to webkit-based desktop browsers and Firefox 25 (and later) on the Mac.
+    .antialiased { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+
+    // Get rid of gap under images by making them display: inline-block; by default
+    img {
+      display: inline-block;
+      vertical-align: middle;
+    }
+
+    //
+    // Global resets for forms
+    //
+
+    // Make sure textarea takes on height automatically
+    textarea { height: auto; min-height: 50px; }
+
+    // Make select elements 100% width by default
+    select { width: 100%; }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_grid.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_grid.scss
@@ -1,0 +1,292 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-grid-classes: $include-html-classes !default;
+$include-xl-html-grid-classes: false !default;
+
+$row-width: rem-calc(1000) !default;
+$total-columns: 12 !default;
+
+$last-child-float: $opposite-direction !default;
+
+//
+// Grid Functions
+//
+
+// Deprecated: We'll drop support for this in 5.1, use grid-calc()
+@function gridCalc($colNumber, $totalColumns) {
+  @warn "gridCalc() is deprecated, use grid-calc()";
+  @return grid-calc($colNumber, $totalColumns);
+}
+
+// @FUNCTION
+// $colNumber - Found in settings file
+// $totalColumns - Found in settings file
+@function grid-calc($colNumber, $totalColumns) {
+  $result: percentage(($colNumber / $totalColumns));
+  @if $result == 0% { $result: 0; }
+  @return $result;
+}
+
+//
+// @mixins
+//
+
+// For creating container, nested, and collapsed rows.
+//
+//
+// $behavior - Any special behavior for this row? Default: false. Options: nest, collapse, nest-collapse, false.
+@mixin grid-row($behavior: false) {
+
+  // use @include grid-row(nest); to include a nested row
+  @if $behavior == nest {
+    margin: 0 (-($column-gutter/2));
+    max-width: none;
+    width: auto;
+  }
+
+  // use @include grid-row(collapse); to collapsed a container row margins
+  @else if $behavior == collapse {
+    margin: 0;
+    max-width: $row-width;
+    width: 100%;
+  }
+
+  // use @include grid-row(nest-collapse); to collapse outer margins on a nested row
+  @else if $behavior == nest-collapse {
+    margin: 0;
+    max-width: none;
+    width: auto;
+  }
+
+  // use @include grid-row; to use a container row
+  @else {
+    margin: 0 auto;
+    max-width: $row-width;
+    width: 100%;
+  }
+
+  // Clearfix for all rows
+  @include clearfix();
+}
+
+// Creates a column, should be used inside of a media query to control layouts
+//
+// $columns - The number of columns this should be
+// $last-column - Is this the last column? Default: false.
+// $center - Center these columns? Default: false.
+// $offset - # of columns to offset. Default: false.
+// $push - # of columns to push. Default: false.
+// $pull - # of columns to pull. Default: false.
+// $collapse - Get rid of gutter padding on column? Default: false.
+// $float - Should this float? Default: true. Options: true, false, left, right.
+@mixin grid-column(
+  $columns:false,
+  $last-column:false,
+  $center:false,
+  $offset:false,
+  $push:false,
+  $pull:false,
+  $collapse:false,
+  $float:true,
+  $position:false) {
+
+  // If positioned for default .column, include relative position
+  // push and pull require position set
+  @if $position or $push or $pull {
+    position: relative;
+  }
+
+  // If collapsed, get rid of gutter padding
+  @if $collapse {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  // Gutter padding whenever a column isn't set to collapse
+  // (use $collapse:null to do nothing)
+  @else if $collapse == false {
+    padding-left: ($column-gutter / 2);
+    padding-right: ($column-gutter / 2);
+  }
+
+  // If a column number is given, calculate width
+  @if $columns {
+    width: grid-calc($columns, $total-columns);
+
+    // If last column, float naturally instead of to the right
+    @if $last-column { float: $opposite-direction; }
+  }
+
+  // Source Ordering, adds left/right depending on which you use.
+  @if $push { #{$default-float}: grid-calc($push, $total-columns); #{$opposite-direction}: auto; }
+  @if $pull { #{$opposite-direction}: grid-calc($pull, $total-columns); #{$default-float}: auto; }
+
+  @if $float and $last-column == false {
+    @if $float == left or $float == true { float: $default-float; }
+    @else if $float == right { float: $opposite-direction; }
+    @else { float: none; }
+  }
+
+  // If centered, get rid of float and add appropriate margins
+  @if $center {
+    margin-#{$default-float}: auto;
+    margin-#{$opposite-direction}: auto;
+    float: none;
+  }
+
+  // If offset, calculate appropriate margins
+  @if $offset { margin-#{$default-float}: grid-calc($offset, $total-columns) !important; }
+
+}
+
+// Create presentational classes for grid
+//
+// $size - Name of class to use, i.e. "large" will generate .large-1, .large-2, etc.
+@mixin grid-html-classes($size) {
+
+  @for $i from 0 through $total-columns - 1 {
+    .#{$size}-push-#{$i} {
+      @include grid-column($push:$i, $collapse:null, $float:false);
+    }
+    .#{$size}-pull-#{$i} {
+      @include grid-column($pull:$i, $collapse:null, $float:false);
+    }
+  }
+
+  .column,
+  .columns { @include grid-column($columns:false, $position:true); }
+
+
+  @for $i from 1 through $total-columns {
+    .#{$size}-#{$i} { @include grid-column($columns:$i, $collapse:null, $float:false); }
+  }
+
+  @for $i from 0 through $total-columns - 1 {
+    .#{$size}-offset-#{$i} { @include grid-column($offset:$i, $collapse:null, $float:false); }
+  }
+
+  .#{$size}-reset-order {
+    float: $default-float;
+    left: auto;
+    margin-#{$default-float}: 0;
+    margin-#{$opposite-direction}: 0;
+    right: auto;
+  }
+
+  .column.#{$size}-centered,
+  .columns.#{$size}-centered { @include grid-column($center:true, $collapse:null, $float:false); }
+
+  .column.#{$size}-uncentered,
+  .columns.#{$size}-uncentered {
+    float: $default-float;
+    margin-#{$default-float}: 0;
+    margin-#{$opposite-direction}: 0;
+  }
+
+  // Fighting [class*="column"] + [class*="column"]:last-child
+  .column.#{$size}-centered:last-child,
+  .columns.#{$size}-centered:last-child{
+    float: none;
+  }
+
+  // Fighting .column.<previous-size>-centered:last-child
+  .column.#{$size}-uncentered:last-child,
+  .columns.#{$size}-uncentered:last-child {
+    float: $default-float;
+  }
+
+  .column.#{$size}-uncentered.opposite,
+  .columns.#{$size}-uncentered.opposite {
+    float: $opposite-direction;
+  }
+
+  .row {
+    &.#{$size}-collapse {
+      > .column,
+      > .columns { @include grid-column($collapse:true, $float:false); }
+
+      .row {margin-left:0; margin-right:0;}
+    }
+    &.#{$size}-uncollapse {
+      > .column,
+      > .columns {
+        @include grid-column;
+      }
+    }
+  }
+}
+
+@include exports("grid") {
+  @if $include-html-grid-classes {
+    .row {
+      @include grid-row;
+
+      &.collapse {
+         > .column,
+         > .columns { @include grid-column($collapse:true, $float:false); }
+
+        .row {margin-left:0; margin-right:0;}
+      }
+
+      .row { @include grid-row($behavior:nest);
+        &.collapse { @include grid-row($behavior:nest-collapse); }
+      }
+    }
+
+    .column,
+    .columns { @include grid-column($columns:$total-columns); }
+
+    .column,
+    .columns {
+      & + &:last-child {
+        float: $last-child-float;
+      }
+      & + &.end {
+        float: $default-float;
+      }
+    }
+
+    @media #{$small-up} {
+      @include grid-html-classes($size:small);
+    }
+
+    @media #{$medium-up} {
+      @include grid-html-classes($size:medium);
+      // Old push and pull classes
+      @for $i from 0 through $total-columns - 1 {
+        .push-#{$i} {
+          @include grid-column($push:$i, $collapse:null, $float:false);
+        }
+        .pull-#{$i} {
+          @include grid-column($pull:$i, $collapse:null, $float:false);
+        }
+      }
+    }
+    @media #{$large-up} {
+      @include grid-html-classes($size:large);
+      @for $i from 0 through $total-columns - 1 {
+        .push-#{$i} {
+          @include grid-column($push:$i, $collapse:null, $float:false);
+        }
+        .pull-#{$i} {
+          @include grid-column($pull:$i, $collapse:null, $float:false);
+        }
+      }
+    }
+  }
+  @if $include-xl-html-grid-classes {
+    @media #{$xlarge-up} {
+      @include grid-html-classes($size:xlarge);
+    }
+    @media #{$xxlarge-up} {
+      @include grid-html-classes($size:xxlarge);
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_icon-bar.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_icon-bar.scss
@@ -1,0 +1,460 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+
+// @name
+// @dependencies _global.scss
+
+$include-html-icon-bar-classes: $include-html-classes !default;
+
+// @variables
+
+// We use these to style the icon-bar and items
+$icon-bar-bg: $oil !default;
+$icon-bar-font-color: $white !default;
+$icon-bar-font-color-hover: $icon-bar-font-color !default;
+$icon-bar-font-size: px(1rem) !default;
+$icon-bar-hover-color: $primary-color !default;
+$icon-bar-icon-color: $white !default;
+$icon-bar-icon-color-hover: $icon-bar-icon-color !default;
+$icon-bar-icon-size: px(1.875rem) !default;
+$icon-bar-image-width: px(1.875rem) !default;
+$icon-bar-image-height: px(1.875rem) !default;
+$icon-bar-active-color: $primary-color !default;
+$icon-bar-item-padding: px(1.25rem) !default;
+
+// We use this to set default opacity and cursor for disabled icons.
+$icon-bar-disabled-opacity: .7 !default;
+$icon-bar-disabled-cursor: $cursor-disabled-value !default;
+
+
+//
+// @mixins
+//
+
+// We use this mixin to create the base styles for our Icon bar element.
+//
+@mixin icon-bar-base() {
+  display: inline-block;
+  font-size: 0;
+  width: 100%;
+
+  > * {
+    display: block;
+    float: left;
+    font-size: $icon-bar-font-size;
+    margin: 0 auto;
+    padding: $icon-bar-item-padding;
+    text-align: center;
+    width: 25%;
+
+    i, img {
+      display: block;
+      margin: 0 auto;
+
+      & + label {
+        margin-top: px(.0625rem);
+      }
+    }
+
+    i {
+      font-size: $icon-bar-icon-size;
+      vertical-align: middle;
+    }
+
+    img {
+      height: $icon-bar-image-height;
+      width: $icon-bar-image-width;
+    }
+  }
+
+  &.label-right > * {
+
+    i, img {
+      display: inline-block;
+      margin: 0 px(.0625rem) 0 0;
+
+      & + label {
+        margin-top: 0;
+      }
+    }
+
+    label { display: inline-block; }
+  }
+
+  &.vertical.label-right > * {
+    text-align: left;
+  }
+
+  &.vertical, &.small-vertical{
+    height: 100%;
+    width: auto;
+
+    .item {
+      float: none;
+      margin: auto;
+      width: auto;
+    }
+  }
+
+  &.medium-vertical {
+    @media #{$medium-up} {
+      height: 100%;
+      width: auto;
+
+      .item {
+        float: none;
+        margin: auto;
+        width: auto;
+      }
+    }
+  }
+  &.large-vertical {
+    @media #{$large-up} {
+      height: 100%;
+      width: auto;
+
+      .item {
+        float: none;
+        margin: auto;
+        width: auto;
+      }
+    }
+  }
+}
+
+// We use this mixin to create the size styles for icon bars.
+@mixin icon-bar-size(
+  $padding: $icon-bar-item-padding,
+  $font-size: $icon-bar-font-size,
+  $icon-size: $icon-bar-icon-size,
+  $image-width: $icon-bar-image-width,
+  $image-height: $icon-bar-image-height) {
+
+  > * {
+    font-size: $font-size;
+    padding: $padding;
+
+    i, img {
+
+      & + label {
+        margin-top: px(.0625rem);
+        font-size: $font-size;
+      }
+    }
+
+    i {
+      font-size: $icon-size;
+    }
+
+    img {
+      height: $image-height;
+      width: $image-width;
+    }
+  }
+
+}
+
+@mixin icon-bar-style(
+  $bar-bg:$icon-bar-bg,
+  $bar-font-color:$icon-bar-font-color,
+  $bar-font-color-hover:$icon-bar-font-color-hover,
+  $bar-hover-color:$icon-bar-hover-color,
+  $bar-icon-color:$icon-bar-icon-color,
+  $bar-icon-color-hover:$icon-bar-icon-color-hover,
+  $bar-active-color:$icon-bar-active-color,
+  $base-style:true,
+  $disabled:false) {
+
+  @if $base-style {
+
+    background: $bar-bg;
+
+    > * {
+      label { color: $bar-font-color; }
+
+      i { color: $bar-icon-color; }
+    }
+
+    > a:hover {
+
+      background: $bar-hover-color;
+
+      label { color: $bar-font-color-hover; }
+
+      i { color: $bar-icon-color-hover; }
+    }
+
+        > a.active {
+
+      background: $bar-active-color;
+
+      label { color: $bar-font-color-hover; }
+
+      i { color: $bar-icon-color-hover; }
+    }
+  }
+  @if $disabled {
+    .item.disabled {
+      cursor: $icon-bar-disabled-cursor;
+      opacity: $icon-bar-disabled-opacity;
+      pointer-events: none;
+      >* {
+        opacity: $icon-bar-disabled-opacity;
+        cursor: $icon-bar-disabled-cursor;
+      }
+    }
+  }
+
+}
+
+// We use this to quickly create icon bars with a single mixin
+// $height - The overall calculated height of the icon bar (horizontal)
+// $bar-bg - the background color of the bar
+// $bar-font-color - the font color
+// $bar-hover-color - okay these are pretty obvious variables
+// $bar-icon-color - maybe we could skip explaining them all? Okay this one does change icon color if you use an icon font
+// $bar-active-color - the color of an active / hover state
+// $base-style - Apply base styles? Default: true.
+// $disabled - Allow disabled icons? Default: false.
+
+@mixin icon-bar(
+  $bar-bg:$icon-bar-bg,
+  $bar-font-color:$icon-bar-font-color,
+  $bar-font-color-hover:$icon-bar-font-color-hover,
+  $bar-hover-color:$icon-bar-hover-color,
+  $bar-icon-color:$icon-bar-icon-color,
+  $bar-icon-color-hover:$icon-bar-icon-color-hover,
+  $bar-active-color:$icon-bar-active-color,
+  $padding: $icon-bar-item-padding,
+  $font-size: $icon-bar-font-size,
+  $icon-size: $icon-bar-icon-size,
+  $image-width: $icon-bar-image-width,
+  $image-height: $icon-bar-image-height,
+  $base-style:true,
+  $disabled:true) {
+    @include icon-bar-base();
+    @include icon-bar-size($padding, $font-size, $icon-size, $image-width, $image-height);
+    @include icon-bar-style($bar-bg, $bar-font-color, $bar-font-color-hover, $bar-hover-color, $bar-icon-color, $bar-icon-color-hover, $bar-active-color, $base-style, $disabled);
+
+  // Counts
+
+  &.two-up {
+    .item { width: 50%; }
+    &.vertical .item, &.small-vertical .item { width: auto; }
+    &.medium-vertical .item {
+      @media #{$medium-up} {
+        width: auto;
+      }
+    }
+    &.large-vertical .item {
+      @media #{$large-up} {
+        width: auto;
+      }
+    }
+  }
+  &.three-up {
+    .item { width: 33.3333%; }
+    &.vertical .item, &.small-vertical .item { width: auto; }
+    &.medium-vertical .item {
+      @media #{$medium-up} {
+        width: auto;
+      }
+    }
+    &.large-vertical .item {
+      @media #{$large-up} {
+        width: auto;
+      }
+    }
+  }
+  &.four-up {
+    .item { width: 25%; }
+    &.vertical .item, &.small-vertical .item { width: auto; }
+    &.medium-vertical .item {
+      @media #{$medium-up} {
+        width: auto;
+      }
+    }
+    &.large-vertical .item {
+      @media #{$large-up} {
+        width: auto;
+      }
+    }
+  }
+  &.five-up {
+    .item { width: 20%; }
+    &.vertical .item, &.small-vertical .item { width: auto; }
+    &.medium-vertical .item {
+      @media #{$medium-up} {
+        width: auto;
+      }
+    }
+    &.large-vertical .item {
+      @media #{$large-up} {
+        width: auto;
+      }
+    }
+  }
+  &.six-up {
+    .item { width: 16.66667%; }
+    &.vertical .item, &.small-vertical .item { width: auto; }
+    &.medium-vertical .item {
+      @media #{$medium-up} {
+        width: auto;
+      }
+    }
+    &.large-vertical .item {
+      @media #{$large-up} {
+        width: auto;
+      }
+    }
+  }
+  &.seven-up {
+    .item { width: 14.28571%; }
+    &.vertical .item, &.small-vertical .item { width: auto; }
+    &.medium-vertical .item {
+      @media #{$medium-up} {
+            width: auto;
+      }
+    }
+    &.large-vertical .item {
+      @media #{$large-up} {
+         width: auto;
+      }
+    }
+  }
+  &.eight-up {
+    .item { width: 12.5%; }
+    &.vertical .item, &.small-vertical .item { width: auto; }
+    &.medium-vertical .item {
+      @media #{$medium-up} {
+            width: auto;
+      }
+    }
+    &.large-vertical .item {
+      @media #{$large-up} {
+         width: auto;
+      }
+    }
+  }
+}
+
+@include exports("icon-bar") {
+  @if $include-html-icon-bar-classes {
+    .icon-bar {
+      @include icon-bar;
+    }
+  }
+}
+
+@if $include-html-icon-bar-classes {
+
+  // toolbar styles
+
+  .icon-bar {
+
+    // Counts
+
+    &.two-up {
+      .item { width: 50%; }
+      &.vertical .item, &.small-vertical .item { width: auto; }
+      &.medium-vertical .item {
+        @media #{$medium-up} {
+          width: auto;
+        }
+      }
+      &.large-vertical .item {
+        @media #{$large-up} {
+          width: auto;
+        }
+      }
+    }
+    &.three-up {
+      .item { width: 33.3333%; }
+      &.vertical .item, &.small-vertical .item { width: auto; }
+      &.medium-vertical .item {
+        @media #{$medium-up} {
+          width: auto;
+        }
+      }
+      &.large-vertical .item {
+        @media #{$large-up} {
+          width: auto;
+        }
+      }
+    }
+    &.four-up {
+      .item { width: 25%; }
+      &.vertical .item, &.small-vertical .item { width: auto; }
+      &.medium-vertical .item {
+        @media #{$medium-up} {
+          width: auto;
+        }
+      }
+      &.large-vertical .item {
+        @media #{$large-up} {
+          width: auto;
+        }
+      }
+    }
+    &.five-up {
+      .item { width: 20%; }
+      &.vertical .item, &.small-vertical .item { width: auto; }
+      &.medium-vertical .item {
+        @media #{$medium-up} {
+          width: auto;
+        }
+      }
+      &.large-vertical .item {
+        @media #{$large-up} {
+          width: auto;
+        }
+      }
+    }
+    &.six-up {
+      .item { width: 16.66667%; }
+      &.vertical .item, &.small-vertical .item { width: auto; }
+      &.medium-vertical .item {
+        @media #{$medium-up} {
+          width: auto;
+        }
+      }
+      &.large-vertical .item {
+        @media #{$large-up} {
+          width: auto;
+        }
+      }
+    }
+    &.seven-up {
+      .item { width: 14.28571%; }
+      &.vertical .item, &.small-vertical .item { width: auto; }
+      &.medium-vertical .item {
+        @media #{$medium-up} {
+              width: auto;
+        }
+      }
+      &.large-vertical .item {
+        @media #{$large-up} {
+           width: auto;
+        }
+      }
+    }
+    &.eight-up {
+      .item { width: 12.5%; }
+      &.vertical .item, &.small-vertical .item { width: auto; }
+      &.medium-vertical .item {
+        @media #{$medium-up} {
+              width: auto;
+        }
+      }
+      &.large-vertical .item {
+        @media #{$large-up} {
+           width: auto;
+        }
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_inline-lists.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_inline-lists.scss
@@ -1,0 +1,58 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-inline-list-classes: $include-html-classes !default;
+
+// We use this to control the margins and padding of the inline list.
+$inline-list-top-margin: 0 !default;
+$inline-list-opposite-margin: 0 !default;
+$inline-list-bottom-margin: rem-calc(17) !default;
+$inline-list-default-float-margin: rem-calc(-22) !default;
+$inline-list-default-float-list-margin: rem-calc(22) !default;
+
+$inline-list-padding: 0 !default;
+
+// We use this to control the overflow of the inline list.
+$inline-list-overflow: hidden !default;
+
+// We use this to control the list items
+$inline-list-display: block !default;
+
+// We use this to control any elements within list items
+$inline-list-children-display: block !default;
+
+//
+// @mixins
+//
+// We use this mixin to create inline lists
+@mixin inline-list {
+  list-style: none;
+  margin-top: $inline-list-top-margin;
+  margin-bottom: $inline-list-bottom-margin;
+  margin-#{$default-float}: $inline-list-default-float-margin;
+  margin-#{$opposite-direction}: $inline-list-opposite-margin;
+  overflow: $inline-list-overflow;
+  padding: $inline-list-padding;
+
+  > li {
+    display: $inline-list-display;
+    float: $default-float;
+    list-style: none;
+    margin-#{$default-float}: $inline-list-default-float-list-margin;
+    > * { display: $inline-list-children-display; }
+  }
+}
+
+@include exports("inline-list") {
+  @if $include-html-inline-list-classes {
+    .inline-list {
+      @include inline-list();
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_joyride.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_joyride.scss
@@ -1,0 +1,220 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-joyride-classes: $include-html-classes !default;
+
+// Controlling default Joyride styles
+$joyride-tip-bg: $oil !default;
+$joyride-tip-default-width: 300px !default;
+$joyride-tip-padding: rem-calc(18 20 24) !default;
+$joyride-tip-border: solid 1px $charcoal !default;
+$joyride-tip-radius: 4px !default;
+$joyride-tip-position-offset: 22px !default;
+
+// Here, we're setting the tip font styles
+$joyride-tip-font-color: $white !default;
+$joyride-tip-font-size: rem-calc(14) !default;
+$joyride-tip-header-weight: $font-weight-bold !default;
+
+// This changes the nub size
+$joyride-tip-nub-size: 10px !default;
+
+// This adjusts the styles for the timer when its enabled
+$joyride-tip-timer-width: 50px !default;
+$joyride-tip-timer-height: 3px !default;
+$joyride-tip-timer-color: $steel !default;
+
+// This changes up the styles for the close button
+$joyride-tip-close-color: $monsoon !default;
+$joyride-tip-close-size: 24px !default;
+$joyride-tip-close-weight: $font-weight-normal !default;
+
+// When Joyride is filling the screen, we use this style for the bg
+$joyride-screenfill: rgba(0,0,0,0.5) !default;
+
+
+// We decided not to make a mixin for this because it relies on
+// predefined classes to work properly.
+@include exports("joyride") {
+  @if $include-html-joyride-classes {
+
+    /* Foundation Joyride */
+    .joyride-list { display: none; }
+
+    /* Default styles for the container */
+    .joyride-tip-guide {
+      background: $joyride-tip-bg;
+      color: $joyride-tip-font-color;
+      display: none;
+      font-family: inherit;
+      font-weight: $font-weight-normal;
+      position: absolute;
+      top: 0;
+      width: 95%;
+      z-index: 101;
+      #{$default-float}: 2.5%;
+    }
+
+    .lt-ie9 .joyride-tip-guide {
+      margin-#{$default-float}: -400px;
+      max-width: 800px;
+      #{$default-float}: 50%;
+    }
+
+    .joyride-content-wrapper {
+      padding: $joyride-tip-padding;
+      width: 100%;
+
+      .button { margin-bottom: 0 !important; }
+
+      .joyride-prev-tip { margin-right: 10px; }
+    }
+
+    /* Add a little css triangle pip, older browser just miss out on the fanciness of it */
+    .joyride-tip-guide {
+      .joyride-nub {
+        border: $joyride-tip-nub-size solid $joyride-tip-bg;
+        display: block;
+        height: 0;
+        position: absolute;
+        width: 0;
+        #{$default-float}: $joyride-tip-position-offset;
+
+        &.top {
+          border-color: $joyride-tip-bg;
+          border-top-color: transparent !important;
+          border-top-style: solid;
+          border-#{$default-float}-color: transparent !important;
+          border-#{$opposite-direction}-color: transparent !important;
+          top: -($joyride-tip-nub-size*2);
+        }
+        &.bottom {
+          border-color: $joyride-tip-bg !important;
+          border-bottom-color: transparent !important;
+          border-bottom-style: solid;
+          border-#{$default-float}-color: transparent !important;
+          border-#{$opposite-direction}-color: transparent !important;
+          bottom: -($joyride-tip-nub-size*2);
+        }
+
+        &.right { right: -($joyride-tip-nub-size*2); }
+        &.left { left: -($joyride-tip-nub-size*2); }
+      }
+    }
+
+    /* Typography */
+    .joyride-tip-guide h1,
+    .joyride-tip-guide h2,
+    .joyride-tip-guide h3,
+    .joyride-tip-guide h4,
+    .joyride-tip-guide h5,
+    .joyride-tip-guide h6 {
+      color: $joyride-tip-font-color;
+      font-weight: $joyride-tip-header-weight;
+      line-height: 1.25;
+      margin: 0;
+    }
+    .joyride-tip-guide p {
+      font-size: $joyride-tip-font-size;
+      line-height: 1.3;
+      margin: rem-calc(0 0 18 0);
+    }
+
+    .joyride-timer-indicator-wrap {
+      border: $joyride-tip-border;
+      bottom: rem-calc(16);
+      height: $joyride-tip-timer-height;
+      position: absolute;
+      width: $joyride-tip-timer-width;
+      #{$opposite-direction}: rem-calc(17);
+    }
+    .joyride-timer-indicator {
+      background: $joyride-tip-timer-color;
+      display: block;
+      height: inherit;
+      width: 0;
+    }
+
+    .joyride-close-tip {
+      color: $joyride-tip-close-color !important;
+      font-size: $joyride-tip-close-size;
+      font-weight: $joyride-tip-close-weight;
+      line-height: .5 !important;
+      position: absolute;
+      text-decoration: none;
+      top: 10px;
+      #{$opposite-direction}: 12px;
+
+      &:hover,
+      &:focus { color: $smoke !important; }
+    }
+
+    .joyride-modal-bg {
+      background: $joyride-screenfill;
+      cursor: $cursor-pointer-value;
+      display: none;
+      height: 100%;
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 100;
+      #{$default-float}: 0;
+    }
+
+    .joyride-expose-wrapper {
+      background-color: $white;
+      border-radius: 3px;
+      box-shadow: 0 0 15px $white;
+      position: absolute;
+      z-index: 102;
+    }
+
+    .joyride-expose-cover {
+      background: transparent;
+      border-radius: 3px;
+      left: 0;
+      position: absolute;
+      top: 0;
+      z-index: 9999;
+    }
+
+
+    /* Styles for screens that are at least 768px; */
+    @media #{$small} {
+      .joyride-tip-guide { width: $joyride-tip-default-width; #{$default-float}: inherit;
+        .joyride-nub {
+          &.bottom {
+            border-color: $joyride-tip-bg !important;
+            border-bottom-color: transparent !important;
+            border-#{$default-float}-color: transparent !important;
+            border-#{$opposite-direction}-color: transparent !important;
+            bottom: -($joyride-tip-nub-size*2);
+          }
+          &.right {
+            border-color: $joyride-tip-bg !important;
+            border-right-color: transparent !important; border-bottom-color: transparent !important;
+            border-top-color: transparent !important;
+            left: auto;
+            right: -($joyride-tip-nub-size*2);
+            top: $joyride-tip-position-offset;
+          }
+          &.left {
+            border-color: $joyride-tip-bg !important;
+            border-bottom-color: transparent !important;
+            border-left-color: transparent !important;
+            border-top-color: transparent !important;
+            left: -($joyride-tip-nub-size*2);
+            right: auto;
+            top: $joyride-tip-position-offset;
+          }
+        }
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_keystrokes.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_keystrokes.scss
@@ -1,0 +1,60 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-keystroke-classes: $include-html-classes !default;
+
+// We use these to control text styles.
+$keystroke-font: "Consolas", "Menlo", "Courier", monospace !default;
+$keystroke-font-size: inherit !default;
+$keystroke-font-color: $jet !default;
+$keystroke-font-color-alt: $white !default;
+$keystroke-function-factor: -7% !default;
+
+// We use this to control keystroke padding.
+$keystroke-padding: rem-calc(2 4 0) !default;
+
+// We use these to control background and border styles.
+$keystroke-bg: scale-color($white, $lightness: $keystroke-function-factor) !default;
+$keystroke-border-style: solid !default;
+$keystroke-border-width: 1px !default;
+$keystroke-border-color: scale-color($keystroke-bg, $lightness: $keystroke-function-factor) !default;
+$keystroke-radius: $global-radius !default;
+
+//
+// @mixins
+//
+// We use this mixin to create keystroke styles.
+// $bg - Default: $keystroke-bg || scale-color($white, $lightness: $keystroke-function-factor) !default;
+@mixin keystroke($bg:$keystroke-bg) {
+  // This find the lightness percentage of the background color.
+  $bg-lightness: lightness($bg);
+  background-color: $bg;
+  border-color: scale-color($bg, $lightness: $keystroke-function-factor);
+
+  // We adjust the font color based on the brightness of the background.
+  @if $bg-lightness > 70% { color: $keystroke-font-color; }
+  @else { color: $keystroke-font-color-alt; }
+
+  border-style: $keystroke-border-style;
+  border-width: $keystroke-border-width;
+  font-family: $keystroke-font;
+  font-size: $keystroke-font-size;
+  margin: 0;
+  padding: $keystroke-padding;
+}
+
+@include exports("keystroke") {
+  @if $include-html-keystroke-classes  {
+    .keystroke,
+    kbd {
+      @include keystroke;
+      @include radius($keystroke-radius);
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_labels.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_labels.scss
@@ -1,0 +1,106 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-label-classes: $include-html-classes !default;
+
+// We use these to style the labels
+$label-padding: rem-calc(4 8 4) !default;
+$label-radius: $global-radius !default;
+
+// We use these to style the label text
+$label-font-sizing: rem-calc(11) !default;
+$label-font-weight: $font-weight-normal !default;
+$label-font-color: $oil !default;
+$label-font-color-alt: $white !default;
+$label-font-family: $body-font-family !default;
+
+//
+// @mixins
+//
+// We use this mixin to create a default label base.
+@mixin label-base {
+  display: inline-block;
+  font-family: $label-font-family;
+  font-weight: $label-font-weight;
+  line-height: 1;
+  margin-bottom: auto;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+// @mixins
+//
+// We use this mixin to add label size styles.
+// $padding - Used to determine label padding. Default: $label-padding || rem-calc(4 8 4) !default
+// $text-size - Used to determine label text-size. Default: $text-size found in settings
+@mixin label-size($padding:$label-padding, $text-size:$label-font-sizing) {
+  @if $padding { padding: $padding; }
+  @if $text-size { font-size: $text-size; }
+}
+
+// @mixins
+//
+// We use this mixin to add label styles.
+// $bg - Default: $primary-color (found in settings file)
+// $radius - Default: false, Options: true, sets radius to $global-radius (found in settings file)
+@mixin label-style($bg:$primary-color, $radius:false) {
+
+  // We control which background color comes through
+  @if $bg {
+
+    // This find the lightness percentage of the background color.
+    $bg-lightness: lightness($bg);
+
+    background-color: $bg;
+
+    // We control the text color for you based on the background color.
+    @if $bg-lightness < 70% { color: $label-font-color-alt; }
+    @else { color: $label-font-color; }
+  }
+
+  // We use this to control the radius on labels.
+  @if $radius == true { @include radius($label-radius); }
+  @else if $radius { @include radius($radius); }
+
+}
+
+// @mixins
+//
+// We use this to add close buttons to alerts
+// $padding - Default: $label-padding,
+// $text-size - Default: $label-font-sizing,
+// $bg - Default: $primary-color(found in settings file)
+// $radius - Default: false, Options: true which sets radius to $global-radius (found in settings file)
+@mixin label($padding:$label-padding, $text-size:$label-font-sizing, $bg:$primary-color, $radius:false) {
+
+  @include label-base;
+  @include label-size($padding, $text-size);
+  @include label-style($bg, $radius);
+}
+
+@include exports("label") {
+  @if $include-html-label-classes {
+    .label {
+      @include label-base;
+      @include label-size;
+      @include label-style;
+
+      &.radius { @include label-style(false, true); }
+      &.round { @include label-style(false, $radius:1000px); }
+
+      &.alert     { @include label-style($alert-color); }
+      &.warning   { @include label-style($warning-color); }
+      &.success   { @include label-style($success-color); }
+      &.secondary { @include label-style($secondary-color); }
+      &.info      { @include label-style($info-color); }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_magellan.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_magellan.scss
@@ -1,0 +1,34 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-magellan-classes: $include-html-classes !default;
+
+$magellan-bg: $white !default;
+$magellan-padding: 10px !default;
+
+@include exports("magellan") {
+  @if $include-html-magellan-classes {
+
+    #{data('magellan-expedition')}, #{data('magellan-expedition-clone')} {
+      background: $magellan-bg;
+      min-width: 100%;
+      padding: $magellan-padding;
+      z-index: 50;
+
+      .sub-nav {
+        margin-bottom: 0;
+        dd { margin-bottom: 0; }
+        a {
+          line-height: 1.8em;
+        }
+      }
+    }
+
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_offcanvas.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_offcanvas.scss
@@ -1,0 +1,606 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+@import 'type';
+
+// Off Canvas Tab Bar Variables
+$include-html-off-canvas-classes: $include-html-classes !default;
+
+$tabbar-bg: $oil !default;
+$tabbar-height: rem-calc(45) !default;
+$tabbar-icon-width: $tabbar-height !default;
+$tabbar-line-height: $tabbar-height !default;
+$tabbar-color: $white !default;
+$tabbar-middle-padding: 0 rem-calc(10) !default;
+
+// Off Canvas Divider Styles
+$tabbar-left-section-border: solid 1px scale-color($tabbar-bg, $lightness: -50%) !default;
+$tabbar-right-section-border: $tabbar-left-section-border;
+
+
+// Off Canvas Tab Bar Headers
+$tabbar-header-color: $white !default;
+$tabbar-header-weight: $font-weight-bold !default;
+$tabbar-header-line-height: $tabbar-height !default;
+$tabbar-header-margin: 0 !default;
+
+// Off Canvas Menu Variables
+$off-canvas-width: rem-calc(250) !default;
+$off-canvas-height: rem-calc(300) !default;
+$off-canvas-bg: $oil !default;
+$off-canvas-bg-hover: scale-color($tabbar-bg, $lightness: -30%) !default;
+$off-canvas-bg-active: scale-color($tabbar-bg, $lightness: -30%) !default;
+
+// Off Canvas Menu List Variables
+$off-canvas-label-padding: px(.3rem) rem-calc(15) !default;
+$off-canvas-label-color: $aluminum !default;
+$off-canvas-label-text-transform: uppercase !default;
+$off-canvas-label-font-size: rem-calc(12) !default;
+$off-canvas-label-font-weight: $font-weight-bold !default;
+$off-canvas-label-bg: $tuatara !default;
+$off-canvas-label-border-top: 1px solid scale-color($off-canvas-label-bg, $lightness: 14%) !default;
+$off-canvas-label-border-bottom: none !default;
+$off-canvas-label-margin:0 !default;
+$off-canvas-link-padding: rem-calc(10, 15) !default;
+$off-canvas-link-color: rgba($white, .7) !default;
+$off-canvas-link-border-bottom: 1px solid scale-color($off-canvas-bg, $lightness: -25%) !default;
+$off-canvas-back-bg: #444 !default;
+$off-canvas-back-border-top: $off-canvas-label-border-top !default;
+$off-canvas-back-border-bottom: $off-canvas-label-border-bottom !default;
+$off-canvas-back-hover-bg: scale-color($off-canvas-back-bg, $lightness: -30%) !default;
+$off-canvas-back-hover-border-top: 1px solid scale-color($off-canvas-label-bg, $lightness: 14%) !default;
+$off-canvas-back-hover-border-bottom: none !default;
+
+// Off Canvas Menu Icon Variables
+$tabbar-menu-icon-color: $white !default;
+$tabbar-menu-icon-hover: scale-color($tabbar-menu-icon-color, $lightness: -30%) !default;
+
+$tabbar-menu-icon-text-indent: rem-calc(35) !default;
+$tabbar-menu-icon-width: $tabbar-icon-width !default;
+$tabbar-menu-icon-height: $tabbar-height !default;
+$tabbar-menu-icon-padding: 0 !default;
+
+$tabbar-hamburger-icon-width: rem-calc(16) !default;
+$tabbar-hamburger-icon-left: false !default;
+$tabbar-hamburger-icon-top: false !default;
+$tabbar-hamburger-icon-thickness: 1px !default;
+$tabbar-hamburger-icon-gap: 6px !default;
+
+// Off Canvas Back-Link Overlay
+$off-canvas-overlay-transition: background 300ms ease !default;
+$off-canvas-overlay-cursor: pointer !default;
+$off-canvas-overlay-box-shadow: -4px 0 4px rgba($black, .5), 4px 0 4px rgba($black, .5) !default;
+$off-canvas-overlay-background: rgba($white, .2) !default;
+$off-canvas-overlay-background-hover: rgba($white, .05) !default;
+
+// Transition Variables
+$menu-slide: "transform 500ms ease" !default;
+
+
+// MIXINS
+// Remove transition flicker on phones
+@mixin kill-flicker {
+  // -webkit-transform: translateZ(0x);
+  -webkit-backface-visibility: hidden;
+}
+
+// Basic properties for the content wraps
+@mixin wrap-base {
+  position: relative;
+  width: 100%;
+}
+
+@mixin translate3d($tx, $ty, $tz) {
+  -webkit-transform: translate3d($tx, $ty, $tz);
+     -moz-transform: translate3d($tx, $ty, $tz);
+      -ms-transform: translate($tx, $ty);
+       -o-transform: translate3d($tx, $ty, $tz);
+          transform: translate3d($tx, $ty, $tz)
+}
+
+// basic styles for off-canvas menu container
+@mixin off-canvas-menu($position) {
+  @include kill-flicker;
+  * { @include kill-flicker; }
+  background: $off-canvas-bg;
+  bottom: 0;
+  box-sizing: content-box;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: absolute;
+  transition: transform 500ms ease 0s;
+  width: $off-canvas-width;
+  z-index: 1001;
+
+  @if $position == left {
+    @include translate3d(-100%,0,0);
+    left: 0;
+    top: 0;
+  }
+  @if $position == right {
+    @include translate3d(100%,0,0);
+    right: 0;
+    top: 0;
+  }
+  @if $position == top {
+    @include translate3d(0,-100%,0);
+    top: 0;
+    width: 100%;
+    height: $off-canvas-height;
+  }
+  @if $position == bottom {
+    @include translate3d(0,100%,0);
+    bottom: 0;
+    width: 100%;
+    height: $off-canvas-height;
+  }
+}
+
+// OFF CANVAS WRAP
+// Wrap visible content and prevent scroll bars
+@mixin off-canvas-wrap {
+  @include kill-flicker;
+  @include wrap-base;
+  overflow: hidden;
+  &.move-right,
+  &.move-left,
+  &.move-bottom,
+  &.move-top { min-height: 100%; -webkit-overflow-scrolling: touch; }
+}
+
+// INNER WRAP
+// Main content area that moves to reveal the off-canvas nav
+@mixin inner-wrap {
+  // @include kill-flicker;
+  // removed for now till chrome fixes backface issue
+  @include wrap-base;
+  @include clearfix;
+  -webkit-transition: -webkit-#{$menu-slide};
+  -moz-transition: -moz-#{$menu-slide};
+  -ms-transition: -ms-#{$menu-slide};
+  -o-transition: -o-#{$menu-slide};
+  transition: #{$menu-slide};
+}
+
+// TAB BAR
+// This is the tab bar base
+@mixin tab-bar-base {
+  @include kill-flicker;
+
+  // base styles
+  background: $tabbar-bg;
+  color: $tabbar-color;
+  height: $tabbar-height;
+  line-height: $tabbar-line-height;
+
+  // make sure it's below the .exit-off-canvas link
+  position: relative;
+  // z-index: 999;
+
+  // Typography
+  h1, h2, h3, h4, h5, h6 {
+    color: $tabbar-header-color;
+    font-weight: $tabbar-header-weight;
+    line-height: $tabbar-header-line-height;
+    margin: $tabbar-header-margin;
+  }
+  h1, h2, h3, h4 { font-size: $h5-font-size; }
+}
+
+// SMALL SECTIONS
+// These are small sections on the left and right that contain the off-canvas toggle buttons;
+@mixin tabbar-small-section($position) {
+  height: $tabbar-height;
+  position: absolute;
+  top: 0;
+  width: $tabbar-icon-width;
+  @if $position == left {
+    border-right: $tabbar-left-section-border;
+    // box-shadow: 1px 0 0 scale-color($tabbar-bg, $lightness: 13%);
+    left: 0;
+  }
+  @if $position == right {
+    border-left: $tabbar-right-section-border;
+    // box-shadow: -1px 0 0 scale-color($tabbar-bg, $lightness: -50%);
+    right:0;
+  }
+}
+
+@mixin tab-bar-section {
+  height: $tabbar-height;
+  padding: $tabbar-middle-padding;
+  position: absolute;
+  text-align: center;
+  top: 0;
+    &.left { text-align: left; }
+    &.right { text-align: right; }
+
+
+  // still need to make these non-presentational
+  &.left {
+    left: 0;
+    right: $tabbar-icon-width;
+  }
+  &.right {
+    left: $tabbar-icon-width;
+    right: 0;
+  }
+  &.middle {
+    left: $tabbar-icon-width;
+    right: $tabbar-icon-width;
+  }
+}
+
+// OFF CANVAS LIST
+// This is the list of links in the off-canvas menu
+@mixin off-canvas-list {
+  list-style-type: none;
+  margin:0;
+  padding:0;
+
+  li {
+    label {
+      background: $off-canvas-label-bg;
+      border-bottom: $off-canvas-label-border-bottom;
+      border-top: $off-canvas-label-border-top;
+      color: $off-canvas-label-color;
+      display: block;
+      font-size: $off-canvas-label-font-size;
+      font-weight: $off-canvas-label-font-weight;
+      margin: $off-canvas-label-margin;
+      padding: $off-canvas-label-padding;
+      text-transform: $off-canvas-label-text-transform;
+    }
+    a {
+      border-bottom: $off-canvas-link-border-bottom;
+      color: $off-canvas-link-color;
+      display: block;
+      padding: $off-canvas-link-padding;
+      transition: background 300ms ease;
+      &:hover {
+        background: $off-canvas-bg-hover;
+      }
+      &:active {
+        background: $off-canvas-bg-active;
+      }
+    }
+  }
+
+}
+
+// BACK LINK
+// This is an overlay that, when clicked, will toggle off the off canvas menu
+@mixin back-link {
+  @include kill-flicker;
+
+  box-shadow: $off-canvas-overlay-box-shadow;
+  cursor: $off-canvas-overlay-cursor;
+  transition: $off-canvas-overlay-transition;
+
+  // fill the screen
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  background: $off-canvas-overlay-background;
+  bottom: 0;
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1002;
+
+  @media #{$medium-up} {
+    &:hover {
+      background: $off-canvas-overlay-background-hover;
+    }
+  }
+}
+
+//
+// Off-Canvas Submenu Classes
+//
+@mixin off-canvas-submenu($position) {
+  @include kill-flicker;
+  * { @include kill-flicker; }
+  -webkit-overflow-scrolling: touch;
+  background: $off-canvas-bg;
+  bottom: 0;
+  box-sizing: content-box;
+  margin: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: absolute;
+  top: 0;
+  width: $off-canvas-width;
+  height: $off-canvas-height;
+  z-index: 1002;
+  @if $position == left {
+    @include translate3d(-100%,0,0);
+    left: 0;
+  }
+  @if $position == right {
+    @include translate3d(100%,0,0);
+    right: 0;
+  }
+  @if $position == top {
+    @include translate3d(0,-100%,0);
+    top: 0;
+    width: 100%;
+  }
+  @if $position == bottom {
+    @include translate3d(0,100%,0);
+    bottom: 0;
+    width: 100%;
+  }
+  -webkit-transition: -webkit-#{$menu-slide};
+  -moz-transition: -moz-#{$menu-slide};
+  -ms-transition: -ms-#{$menu-slide};
+  -o-transition: -o-#{$menu-slide};
+  transition: #{$menu-slide};
+
+  //back button style like label
+  .back > a {
+    background: $off-canvas-back-bg;
+    border-bottom: $off-canvas-back-border-bottom;
+    border-top: $off-canvas-back-border-top;
+    color: $off-canvas-label-color;
+    font-weight: $off-canvas-label-font-weight;
+    padding: $off-canvas-label-padding;
+    text-transform: $off-canvas-label-text-transform;
+
+    &:hover {
+      background: $off-canvas-back-hover-bg;
+      border-bottom: $off-canvas-back-hover-border-bottom;
+      border-top: $off-canvas-back-hover-border-top;
+    }
+
+    margin: $off-canvas-label-margin;
+    @if $position == right {
+      @if $text-direction == rtl {
+        &:before {
+          @include icon-double-arrows($position: left);
+        }
+      } @else {
+        &:after {
+          @include icon-double-arrows($position: right);
+        }
+      }
+    }
+    @if $position == left {
+      @if $text-direction == rtl {
+        &:after {
+          @include icon-double-arrows($position: right);
+        }
+      } @else {
+        &:before {
+          @include icon-double-arrows($position: left);
+        }
+      }
+    }
+  }
+}
+//Left double angle quote or Right double angle quote chars
+@mixin icon-double-arrows ($position) {
+  @if $position == left {
+    content: "\AB";
+    @if $text-direction == rtl {
+      margin-left: px(.5rem);
+    } @else {
+      margin-right: px(.5rem);
+    }
+  }
+  @if $position == right {
+    content: "\BB";
+    @if $text-direction == rtl {
+      margin-right: px(.5rem);
+    } @else {
+      margin-left: px(.5rem);
+    }
+  }
+  display: inline;
+}
+
+//
+// DEFAULT CLASSES
+//
+@include exports("offcanvas") {
+  @if $include-html-off-canvas-classes {
+
+    .off-canvas-wrap { @include off-canvas-wrap; }
+    .inner-wrap { @include inner-wrap; }
+
+    .tab-bar { @include tab-bar-base; }
+
+    .left-small { @include tabbar-small-section($position: left); }
+    .right-small { @include tabbar-small-section($position: right); }
+
+    .tab-bar-section { @include tab-bar-section; }
+
+    // MENU BUTTON
+    // This is a little bonus. You don't need it for off canvas to work. Mixins to be written in the future.
+    .tab-bar .menu-icon {
+      color: $tabbar-menu-icon-color;
+      display: block;
+      height: $tabbar-menu-icon-height;
+      padding: $tabbar-menu-icon-padding;
+      position: relative;
+      text-indent: $tabbar-menu-icon-text-indent;
+      transform: translate3d(0,0,0);
+      width: $tabbar-menu-icon-width;
+
+      // @include for the hamburger menu-icon
+      //
+      // Arguments as follows: ($width, $left, $top, $thickness, $gap, $color, $hover-color)
+      // $width - Width of hamburger icon in rem Default: $tabbar-hamburger-icon-width.
+      // $left - If false, icon will be centered horizontally || explicitly set value in rem Default: $tabbar-hamburger-icon-left= False
+      // $top - If false, icon will be centered vertically || explicitly set value in rem Default: = False
+      // $thickness - thickness of lines in hamburger icon, set value in px Default: $tabbar-hamburger-icon-thickness = 1px
+      // $gap - spacing between the lines in hamburger icon, set value in px Default: $tabbar-hamburger-icon-gap = 6px
+      // $color - icon color Default: $tabbar-menu-icon-color
+      // $hover-color - icon color when hovered Default: $tabbar-menu-icon-hover
+      // $offcanvas - Set to true
+      @include hamburger($tabbar-hamburger-icon-width, $tabbar-hamburger-icon-left, $tabbar-hamburger-icon-top, $tabbar-hamburger-icon-thickness, $tabbar-hamburger-icon-gap, $tabbar-menu-icon-color, $tabbar-menu-icon-hover, true)
+    }
+
+    .left-off-canvas-menu { @include off-canvas-menu($position: left); }
+    .right-off-canvas-menu { @include off-canvas-menu($position: right); }
+    .top-off-canvas-menu { @include off-canvas-menu($position: top); }
+    .bottom-off-canvas-menu { @include off-canvas-menu($position: bottom); }
+
+    ul.off-canvas-list { @include off-canvas-list; }
+
+
+    // ANIMATION CLASSES
+    // These classes are added with JS and trigger the actual animation.
+    .move-right {
+      > .inner-wrap {
+        @include translate3d($off-canvas-width,0,0);
+      }
+      .exit-off-canvas { @include back-link;}
+    }
+
+    .move-left {
+      > .inner-wrap {
+        @include translate3d(-($off-canvas-width),0,0);
+
+      }
+      .exit-off-canvas { @include back-link; }
+    }
+    .move-top {
+      > .inner-wrap {
+        @include translate3d(0,-($off-canvas-height),0);
+
+      }
+      .exit-off-canvas { @include back-link; }
+    }
+    .move-bottom {
+      > .inner-wrap {
+        @include translate3d(0,($off-canvas-height),0);
+
+      }
+      .exit-off-canvas { @include back-link; }
+    }
+    .offcanvas-overlap {
+      .left-off-canvas-menu, .right-off-canvas-menu,
+      .top-off-canvas-menu, .bottom-off-canvas-menu {
+        -ms-transform: none;
+        -webkit-transform: none;
+        -moz-transform: none;
+        -o-transform: none;
+        transform: none;
+        z-index: 1003;
+      }
+      .exit-off-canvas { @include back-link; }
+    }
+    .offcanvas-overlap-left {
+      .right-off-canvas-menu {
+        -ms-transform: none;
+        -webkit-transform: none;
+        -moz-transform: none;
+        -o-transform: none;
+        transform: none;
+        z-index: 1003;
+      }
+      .exit-off-canvas { @include back-link; }
+    }
+    .offcanvas-overlap-right {
+      .left-off-canvas-menu {
+        -ms-transform: none;
+        -webkit-transform: none;
+        -moz-transform: none;
+        -o-transform: none;
+        transform: none;
+        z-index: 1003;
+      }
+      .exit-off-canvas { @include back-link; }
+    }
+    .offcanvas-overlap-top {
+      .bottom-off-canvas-menu {
+        -ms-transform: none;
+        -webkit-transform: none;
+        -moz-transform: none;
+        -o-transform: none;
+        transform: none;
+        z-index: 1003;
+      }
+      .exit-off-canvas { @include back-link; }
+    }
+    .offcanvas-overlap-bottom {
+      .top-off-canvas-menu {
+        -ms-transform: none;
+        -webkit-transform: none;
+        -moz-transform: none;
+        -o-transform: none;
+        transform: none;
+        z-index: 1003;
+      }
+      .exit-off-canvas { @include back-link; }
+    }
+
+    // Older browsers
+    .no-csstransforms {
+      .left-off-canvas-menu { left: -($off-canvas-width); }
+      .right-off-canvas-menu { right: -($off-canvas-width); }
+      .top-off-canvas-menu { top: -($off-canvas-height); }
+      .bottom-off-canvas-menu { bottom: -($off-canvas-height); }
+
+      .move-left > .inner-wrap { right: $off-canvas-width; }
+      .move-right > .inner-wrap { left: $off-canvas-width; }
+      .move-top > .inner-wrap { right: $off-canvas-height; }
+      .move-bottom > .inner-wrap { left: $off-canvas-height; }
+
+
+    }
+
+    .left-submenu {
+      @include off-canvas-submenu($position: left);
+      &.move-right, &.offcanvas-overlap-right, &.offcanvas-overlap {
+        @include translate3d(0%,0,0);
+      }
+    }
+
+    .right-submenu {
+      @include off-canvas-submenu($position: right);
+      &.move-left, &.offcanvas-overlap-left, &.offcanvas-overlap {
+        @include translate3d(0%,0,0);
+      }
+    }
+
+    .top-submenu {
+      @include off-canvas-submenu($position: top);
+      &.move-bottom, &.offcanvas-overlap-bottom, &.offcanvas-overlap {
+        @include translate3d(0,0%,0);
+      }
+    }
+
+    .bottom-submenu {
+      @include off-canvas-submenu($position: bottom);
+      &.move-top, &.offcanvas-overlap-top, &.offcanvas-overlap {
+        @include translate3d(0,0%,0);
+      }
+    }
+
+    @if $text-direction == rtl {
+      .left-off-canvas-menu ul.off-canvas-list li.has-submenu > a:before {
+        @include icon-double-arrows($position: left);
+      }
+      .right-off-canvas-menu ul.off-canvas-list li.has-submenu > a:after {
+        @include icon-double-arrows($position: right);
+      }
+    } @else {
+      .left-off-canvas-menu ul.off-canvas-list li.has-submenu > a:after {
+        @include icon-double-arrows($position: right);
+      }
+      .right-off-canvas-menu ul.off-canvas-list li.has-submenu > a:before {
+        @include icon-double-arrows($position: left);
+      }
+    }
+
+  }
+}
+
+
+

--- a/situational/assets/print/foundation-print/scss/foundation/components/_orbit.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_orbit.scss
@@ -1,0 +1,388 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+// @variables
+//
+$include-html-orbit-classes: $include-html-classes !default;
+
+// We use these to control the caption styles
+$orbit-container-bg: none !default;
+$orbit-caption-bg: rgba(51,51,51, .8) !default;
+$orbit-caption-font-color: $white !default;
+$orbit-caption-font-size: rem-calc(14) !default;
+$orbit-caption-position: "bottom" !default; // Supported values: "bottom", "under"
+$orbit-caption-padding: rem-calc(10 14) !default;
+$orbit-caption-height: auto !default;
+
+// We use these to control the left/right nav styles
+$orbit-nav-bg: transparent !default;
+$orbit-nav-bg-hover: rgba(0,0,0,0.3) !default;
+$orbit-nav-arrow-color: $white !default;
+$orbit-nav-arrow-color-hover: $white !default;
+
+// We use these to control the timer styles
+$orbit-timer-bg: rgba(255,255,255,0.3) !default;
+$orbit-timer-show-progress-bar: true !default;
+
+// We use these to control the bullet nav styles
+$orbit-bullet-nav-color: $iron !default;
+$orbit-bullet-nav-color-active: $aluminum !default;
+$orbit-bullet-radius: rem-calc(9) !default;
+
+// We use these to controls the style of slide numbers
+$orbit-slide-number-bg: rgba(0,0,0,0) !default;
+$orbit-slide-number-font-color: $white !default;
+$orbit-slide-number-padding: rem-calc(5) !default;
+
+// Graceful Loading Wrapper and preloader
+$wrapper-class: "slideshow-wrapper" !default;
+$preloader-class: "preloader" !default;
+
+// Hide controls on small
+$orbit-nav-hide-for-small: true !default;
+$orbit-bullet-hide-for-small: true !default;
+$orbit-timer-hide-for-small: true !default;
+
+
+@include exports("orbit") {
+  @if $include-html-orbit-classes {
+
+    @-webkit-keyframes rotate {
+      from {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+      }
+      to {
+          -webkit-transform: rotate(360deg);
+          transform: rotate(360deg);
+      }
+    }
+
+
+    @keyframes rotate {
+      from {
+          -webkit-transform: rotate(0deg);
+          -moz-transform: rotate(0deg);
+          -ms-transform: rotate(0deg);
+          transform: rotate(0deg);
+      }
+      to {
+          -webkit-transform: rotate(360deg);
+          -moz-transform: rotate(360deg);
+          -ms-transform: rotate(360deg);
+          transform: rotate(360deg);
+      }
+    }
+
+    /* Orbit Graceful Loading */
+    .#{$wrapper-class} {
+      position: relative;
+
+      ul {
+        // Prevent bullets showing before .orbit-container is loaded
+        list-style-type: none;
+        margin: 0;
+
+        // Hide all list items
+        li,
+        li .orbit-caption { display: none; }
+
+        // ...except for the first one
+        li:first-child { display: block; }
+      }
+
+      .orbit-container { background-color: transparent;
+
+        // Show images when .orbit-container is loaded
+        li { display: block;
+
+          .orbit-caption { display: block; }
+        }
+        .orbit-bullets li {
+          display: inline-block;
+        }
+      }
+
+      // Orbit preloader
+      .#{$preloader-class} {
+        @include radius(1000px);
+        animation-duration: 1.5s;
+        animation-iteration-count: infinite;
+        animation-name: rotate;
+        animation-timing-function: linear;
+        border-color: $charcoal $white;
+        border: solid 3px;
+        display: block;
+        height: 40px;
+        left: 50%;
+        margin-left: -20px;
+        margin-top: -20px;
+        position: absolute;
+        top: 50%;
+        width: 40px;
+      }
+    }
+
+
+    .orbit-container {
+      background: $orbit-container-bg;
+      overflow: hidden;
+      position: relative;
+      width: 100%;
+
+      .orbit-slides-container {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        position: relative;
+
+        // Prevents images (and captions) from disappearing after first rotation on Chrome for Android
+        -webkit-transform: translateZ(0);
+        -moz-transform: translateZ(0);
+        -ms-transform: translateZ(0);
+        -o-transform: translateZ(0);
+        transform: translateZ(0);
+
+        img { display: block; max-width: 100%; }
+
+        > * {
+          position: absolute;
+          top: 0;
+          width: 100%;
+          @if $text-direction == rtl {
+            margin-right: 100%;
+          }
+          @else {
+            margin-left: 100%;
+          }
+
+          &:first-child {
+            @if $text-direction == rtl {
+              margin-right: 0;
+            }
+            @else {
+              margin-left: 0;
+            }
+          }
+
+          .orbit-caption {
+            @if $orbit-caption-position == "bottom" {
+              bottom: 0;
+              position: absolute;
+            } @else if $orbit-caption-position == "under" {
+              position: relative;
+            }
+
+            background-color: $orbit-caption-bg;
+            color: $orbit-caption-font-color;
+            font-size: $orbit-caption-font-size;
+            padding: $orbit-caption-padding;
+            width: 100%;
+          }
+        }
+      }
+
+      .orbit-slide-number {
+        #{$default-float}: 10px;
+        background: $orbit-slide-number-bg;
+        color: $orbit-slide-number-font-color;
+        font-size: 12px;
+        position: absolute;
+        span { font-weight: 700; padding: $orbit-slide-number-padding;}
+        top: 10px;
+        z-index: 10;
+      }
+
+      .orbit-timer {
+        
+        position: absolute;
+        top: 12px;
+        #{$opposite-direction}: 10px;
+        height: 6px;
+        width: 100px;
+        z-index: 10;
+        
+
+        .orbit-progress {
+          @if $orbit-timer-show-progress-bar {
+            height: 3px;
+            background-color: $orbit-timer-bg;
+            display: block;
+            width: 0;
+            position: relative;
+            right: 20px;
+            top: 5px;
+            
+          }
+        }
+
+        // Play button
+        & > span {
+          border: solid 4px $white;
+          border-bottom: none;
+          border-top: none;
+          display: none;
+          height: 14px;
+          position: absolute;
+          top: 0;
+          width: 11px;
+          #{$opposite-direction}: 0;
+        }
+
+        // Pause button
+        &.paused {
+          & > span {
+            top: 0;
+            width: 11px;
+            height: 14px;
+            border: inset 8px;
+            border-left-style: solid;
+            border-color: transparent;
+            border-left-color: $white;
+            #{$opposite-direction}: -4px;
+
+            &.dark {
+              border-left-color: $oil;
+            }
+          }
+        }
+      }
+
+
+
+      &:hover .orbit-timer > span { display: block; }
+
+      // Let's get those controls to be right in the center on each side
+      .orbit-prev,
+      .orbit-next {
+        background-color: $orbit-nav-bg;
+        color: white;
+        height: 60px;
+        line-height: 50px;
+        margin-top: -25px;
+        position: absolute;
+        text-indent: -9999px !important;
+        top: 45%;
+        width: 36px;
+        z-index: 10;
+
+        &:hover {
+          background-color: $orbit-nav-bg-hover;
+        }
+
+        & > span {
+          border: inset 10px;
+          display: block;
+          height: 0;
+          margin-top: -10px;
+          position: absolute;
+          top: 50%;
+          width: 0;
+        }
+      }
+      .orbit-prev { #{$default-float}: 0;
+        & > span {
+          border-#{$opposite-direction}-style: solid;
+          border-color: transparent;
+          border-#{$opposite-direction}-color: $orbit-nav-arrow-color;
+        }
+        &:hover > span {
+          border-#{$opposite-direction}-color: $orbit-nav-arrow-color-hover;
+        }
+      }
+      .orbit-next { #{$opposite-direction}: 0;
+        & > span {
+          border-color: transparent;
+          border-#{$default-float}-style: solid;
+          border-#{$default-float}-color: $orbit-nav-arrow-color;
+          #{$default-float}: 50%;
+          margin-#{$default-float}: -4px;
+        }
+        &:hover > span {
+          border-#{$default-float}-color: $orbit-nav-arrow-color-hover;
+        }
+      }
+    }
+
+    .orbit-bullets-container { text-align: center; }
+    .orbit-bullets {
+      display: block;
+      float: none;
+      margin: 0 auto 30px auto;
+      overflow: hidden;
+      position: relative;
+      text-align: center;
+      top: 10px;
+
+      li {
+        background: $orbit-bullet-nav-color;
+        cursor: pointer;
+        display: inline-block;
+        // float: $default-float;
+        float: none;
+        height: $orbit-bullet-radius;
+        margin-#{$opposite-direction}: 6px;
+        width: $orbit-bullet-radius;
+
+        @include radius(1000px);
+
+        &.active {
+          background: $orbit-bullet-nav-color-active;
+        }
+
+        &:last-child { margin-#{$opposite-direction}: 0; }
+      }
+    }
+
+    .touch {
+      .orbit-container {
+        .orbit-prev,
+        .orbit-next { display: none; }
+      }
+
+      .orbit-bullets { display: none; }
+    }
+
+
+    @media #{$medium-up} {
+
+      .touch {
+        .orbit-container {
+          .orbit-prev,
+          .orbit-next { display: inherit; }
+        }
+
+        .orbit-bullets { display: block; }
+      }
+
+    }
+
+    @media #{$small-only} {
+      .orbit-stack-on-small {
+        .orbit-slides-container {height: auto !important;}
+        .orbit-slides-container > * {
+          margin:0  !important;
+          opacity: 1 !important;
+          position: relative;
+        }
+
+        .orbit-slide-number {
+          display: none;
+        }
+      }
+
+      @if $orbit-timer-hide-for-small {
+         .orbit-timer{display: none;}
+      }
+      @if $orbit-nav-hide-for-small {
+         .orbit-next,.orbit-prev{display: none;}
+      }
+      @if $orbit-bullet-hide-for-small {
+         .orbit-bullets{display: none;}
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_pagination.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_pagination.scss
@@ -1,0 +1,163 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-pagination-classes: $include-html-classes !default;
+
+// We use these to control the pagination container
+$pagination-height: rem-calc(24) !default;
+$pagination-margin: rem-calc(-5) !default;
+
+// We use these to set the list-item properties
+$pagination-li-float: $default-float !default;
+$pagination-li-height: rem-calc(24) !default;
+$pagination-li-font-color: $jet !default;
+$pagination-li-font-size: rem-calc(14) !default;
+$pagination-li-margin: rem-calc(5) !default;
+
+// We use these for the pagination anchor links
+$pagination-link-pad: rem-calc(1 10 1) !default;
+$pagination-link-font-color: $aluminum !default;
+$pagination-link-active-bg: scale-color($white, $lightness: -10%) !default;
+
+// We use these for disabled anchor links
+$pagination-link-unavailable-cursor: default !default;
+$pagination-link-unavailable-font-color: $aluminum !default;
+$pagination-link-unavailable-bg-active: transparent !default;
+
+// We use these for currently selected anchor links
+$pagination-link-current-background: $primary-color !default;
+$pagination-link-current-font-color: $white !default;
+$pagination-link-current-font-weight: $font-weight-bold !default;
+$pagination-link-current-cursor: default !default;
+$pagination-link-current-active-bg: $primary-color !default;
+
+// @mixins
+//
+// Style the pagination container. Currently only used when centering elements.
+// $center - Default: false, Options: true
+@mixin pagination-container($center:false) {
+  @if $center { text-align: center; }
+}
+
+// @mixins
+// Style unavailable list items
+@mixin pagination-unavailable-item {
+  a, button {
+    cursor: $pagination-link-unavailable-cursor;
+    color: $pagination-link-unavailable-font-color;
+    pointer-events: none;
+  }
+  &:hover a,
+  & a:focus,
+
+  &:hover button,
+  & button:focus
+  { background: $pagination-link-unavailable-bg-active; }
+}
+// @mixins
+// Style the current list item. Do not assume that the current item has
+// an anchor <a> element.
+// $has-anchor - Default: true, Options: false
+@mixin pagination-current-item($has-anchor: true) {
+  @if $has-anchor {
+    a, button {
+      background: $pagination-link-current-background;
+      color: $pagination-link-current-font-color;
+      cursor: $pagination-link-current-cursor;
+      font-weight: $pagination-link-current-font-weight;
+
+      &:hover,
+      &:focus { background: $pagination-link-current-active-bg; }
+    }
+  } @else {
+    background: $pagination-link-current-background;
+    color: $pagination-link-current-font-color;
+    cursor: $pagination-link-current-cursor;
+    font-weight: $pagination-link-current-font-weight;
+    height: auto;
+    padding: $pagination-link-pad;
+    @include radius;
+
+    &:hover,
+    &:focus { background: $pagination-link-current-active-bg; }
+  }
+}
+
+// @mixins
+//
+// We use this mixin to set the properties for the creating Foundation pagination
+// $center - Left or center align the li elements. Default: false
+// $base-style - Sets base styles for pagination. Default: true, Options: false
+// $use-default-classes - Makes unavailable & current classes available for use. Default: true
+@mixin pagination($center:false, $base-style:true, $use-default-classes:true) {
+
+  @if $base-style {
+    display: block;
+    margin-#{$default-float}: $pagination-margin;
+    min-height: $pagination-height;
+
+    li {
+      color: $pagination-li-font-color;
+      font-size: $pagination-li-font-size;
+      height: $pagination-li-height;
+      margin-#{$default-float}: $pagination-li-margin;
+
+      a, button {
+        @include radius;
+        @include single-transition(background-color);
+        background: none;
+        color: $pagination-link-font-color;
+        display: block;
+        font-size: 1em;
+        font-weight: normal;
+        line-height: inherit;
+        padding: $pagination-link-pad;
+      }
+
+      &:hover a,
+      a:focus,
+      &:hover button,
+      button:focus
+      { background: $pagination-link-active-bg; }
+
+      @if $use-default-classes {
+        &.unavailable { @include pagination-unavailable-item(); }
+        &.current { @include pagination-current-item(); }
+      }
+    }
+  }
+
+  // Left or center align the li elements
+  li {
+    @if $center {
+      display: inline-block;
+      float: none;
+    } @else {
+      display: block;
+      float: $pagination-li-float;
+    }
+  }
+}
+
+@include exports("pagination") {
+  @if $include-pagination-classes {
+    ul.pagination {
+      @include pagination;
+    }
+
+    /* Pagination centred wrapper */
+    .pagination-centered {
+      @include pagination-container(true);
+
+      ul.pagination {
+        @include pagination(true, false);
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_panels.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_panels.scss
@@ -1,0 +1,107 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-panel-classes: $include-html-classes !default;
+
+// We use these to control the background and border styles
+$panel-bg: scale-color($white, $lightness: -5%) !default;
+$panel-border-style: solid !default;
+$panel-border-size: 1px !default;
+$callout-panel-bg: scale-color($primary-color, $lightness: 94%) !default;
+
+// We use this % to control how much we darken things on hover
+$panel-border-color: scale-color($panel-bg, $lightness: -11%) !default;
+
+// We use these to set default inner padding and bottom margin
+$panel-margin-bottom: rem-calc(20) !default;
+$panel-padding: rem-calc(20) !default;
+
+// We use these to set default font colors
+$panel-font-color: $oil !default;
+$panel-font-color-alt: $white !default;
+
+$panel-header-adjust: true !default;
+$callout-panel-link-color: $primary-color !default;
+$callout-panel-link-color-hover: scale-color($callout-panel-link-color, $lightness: -14%) !default;
+//
+// @mixins
+//
+// We use this mixin to create panels.
+// $bg - Sets the panel background color. Default: $panel-pg || scale-color($white, $lightness: -5%) !default
+// $padding - Sets the panel padding amount. Default: $panel-padding || rem-calc(20)
+// $adjust - Sets the font color based on the darkness of the bg & resets header line-heights for panels. Default: $panel-header-adjust || true
+@mixin panel($bg:$panel-bg, $padding:$panel-padding, $adjust:$panel-header-adjust, $border:true) {
+
+  @if $bg {
+    $bg-lightness: lightness($bg);
+
+    @if $border {
+      border-style: $panel-border-style;
+      border-width: $panel-border-size;
+      border-color: $panel-border-color;
+    } @else {
+      border-style: none;
+      border-width: 0;
+    }
+
+    margin-bottom: $panel-margin-bottom;
+    padding: $padding;
+
+    background: $bg;
+    @if $bg-lightness >= 50% { color: $panel-font-color; }
+    @else { color: $panel-font-color-alt; }
+
+    // Respect the padding, fool.
+    > :first-child { margin-top: 0; }
+    > :last-child { margin-bottom: 0; }
+
+    @if $adjust {
+      // We set the font color based on the darkness of the bg.
+      @if $bg-lightness >= 50% {
+        h1, h2, h3, h4, h5, h6, p, li, dl { color: $panel-font-color; }
+      }
+      @else {
+        h1, h2, h3, h4, h5, h6, p, li, dl { color: $panel-font-color-alt; }
+      }
+
+      // reset header line-heights for panels
+      h1, h2, h3, h4, h5, h6 {
+        line-height: 1; margin-bottom: rem-calc(20) / 2;
+        &.subheader { line-height: 1.4; }
+      }
+    }
+  }
+}
+
+@include exports("panel") {
+  @if $include-html-panel-classes {
+
+    /* Panels */
+    .panel { @include panel;
+
+      &.callout {
+        @include panel($callout-panel-bg);
+        a:not(.button) {
+          color: $callout-panel-link-color;
+
+          &:hover,
+          &:focus {
+            color: $callout-panel-link-color-hover;
+          }
+        }
+      }
+
+      &.radius {
+        @include radius;
+      }
+
+    }
+
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_pricing-tables.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_pricing-tables.scss
@@ -1,0 +1,150 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-pricing-classes: $include-html-classes !default;
+
+// We use this to control the border color
+$price-table-border: solid 1px $gainsboro !default;
+
+// We use this to control the bottom margin of the pricing table
+$price-table-margin-bottom: rem-calc(20) !default;
+
+// We use these to control the title styles
+$price-title-bg: $oil !default;
+$price-title-padding: rem-calc(15 20) !default;
+$price-title-align: center !default;
+$price-title-color: $smoke !default;
+$price-title-weight: $font-weight-normal !default;
+$price-title-size: rem-calc(16) !default;
+$price-title-font-family: $body-font-family !default;
+
+// We use these to control the price styles
+$price-money-bg: $vapor !default;
+$price-money-padding: rem-calc(15 20) !default;
+$price-money-align: center !default;
+$price-money-color: $oil !default;
+$price-money-weight: $font-weight-normal !default;
+$price-money-size: rem-calc(32) !default;
+$price-money-font-family: $body-font-family !default;
+
+
+// We use these to control the description styles
+$price-bg: $white !default;
+$price-desc-color: $monsoon !default;
+$price-desc-padding: rem-calc(15) !default;
+$price-desc-align: center !default;
+$price-desc-font-size: rem-calc(12) !default;
+$price-desc-weight: $font-weight-normal !default;
+$price-desc-line-height: 1.4 !default;
+$price-desc-bottom-border: dotted 1px $gainsboro !default;
+
+// We use these to control the list item styles
+$price-item-color: $oil !default;
+$price-item-padding: rem-calc(15) !default;
+$price-item-align: center !default;
+$price-item-font-size: rem-calc(14) !default;
+$price-item-weight: $font-weight-normal !default;
+$price-item-bottom-border: dotted 1px $gainsboro !default;
+
+// We use these to control the CTA area styles
+$price-cta-bg: $white !default;
+$price-cta-align: center !default;
+$price-cta-padding: rem-calc(20 20 0) !default;
+
+// @mixins
+//
+// We use this to create the container element for the pricing tables
+@mixin pricing-table-container {
+  border: $price-table-border;
+  margin-#{$default-float}: 0;
+  margin-bottom: $price-table-margin-bottom;
+
+  & * {
+    list-style: none;
+    line-height: 1;
+  }
+}
+// @mixins
+//
+// We use this mixin to create the pricing table title styles
+@mixin pricing-table-title {
+  background-color: $price-title-bg;
+  color: $price-title-color;
+  font-family: $price-title-font-family;
+  font-size: $price-title-size;
+  font-weight: $price-title-weight;
+  padding: $price-title-padding;
+  text-align: $price-title-align;
+}
+
+// @mixins
+//
+// We use this mixin to control the pricing table price styles
+@mixin pricing-table-price {
+  background-color: $price-money-bg;
+  color: $price-money-color;
+  font-family: $price-money-font-family;
+  font-size: $price-money-size;
+  font-weight: $price-money-weight;
+  padding: $price-money-padding;
+  text-align: $price-money-align;
+}
+
+// @mixins
+//
+// We use this mixin to create the description styles for the pricing table
+@mixin pricing-table-description {
+  background-color: $price-bg;
+  border-bottom: $price-desc-bottom-border;
+  color: $price-desc-color;
+  font-size: $price-desc-font-size;
+  font-weight: $price-desc-weight;
+  line-height: $price-desc-line-height;
+  padding: $price-desc-padding;
+  text-align: $price-desc-align;
+}
+
+// @mixins
+//
+// We use this mixin to style the bullet items in the pricing table
+@mixin pricing-table-bullet {
+  background-color: $price-bg;
+  border-bottom: $price-item-bottom-border;
+  color: $price-item-color;
+  font-size: $price-item-font-size;
+  font-weight: $price-item-weight;
+  padding: $price-item-padding;
+  text-align: $price-item-align;
+}
+
+// @mixins
+//
+// We use this mixin to style the CTA area of the pricing tables
+@mixin pricing-table-cta {
+  background-color: $price-cta-bg;
+  padding: $price-cta-padding;
+  text-align: $price-cta-align;
+}
+
+@include exports("pricing-table") {
+  @if $include-html-pricing-classes {
+
+    /* Pricing Tables */
+    .pricing-table {
+      @include pricing-table-container;
+
+      .title { @include pricing-table-title; }
+      .price { @include pricing-table-price; }
+      .description { @include pricing-table-description; }
+      .bullet-item { @include pricing-table-bullet; }
+      .cta-button { @include pricing-table-cta; }
+    }
+
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_progress-bars.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_progress-bars.scss
@@ -1,0 +1,85 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+$include-html-media-classes: $include-html-classes !default;
+
+// We use this to set the progress bar height
+$progress-bar-height: rem-calc(25) !default;
+$progress-bar-color: $vapor !default;
+
+// We use these to control the border styles
+$progress-bar-border-color: scale-color($white, $lightness: 20%) !default;
+$progress-bar-border-size: 1px !default;
+$progress-bar-border-style: solid !default;
+$progress-bar-border-radius: $global-radius !default;
+
+// We use these to control the margin & padding
+$progress-bar-pad: rem-calc(2) !default;
+$progress-bar-margin-bottom: rem-calc(10) !default;
+
+// We use these to set the meter colors
+$progress-meter-color: $primary-color !default;
+$progress-meter-secondary-color: $secondary-color !default;
+$progress-meter-success-color: $success-color !default;
+$progress-meter-alert-color: $alert-color !default;
+
+// @mixins
+//
+// We use this to set up the progress bar container
+@mixin progress-container {
+  background-color: $progress-bar-color;
+  border: $progress-bar-border-size $progress-bar-border-style $progress-bar-border-color;
+  height: $progress-bar-height;
+  margin-bottom: $progress-bar-margin-bottom;
+  padding: $progress-bar-pad;
+}
+
+// @mixins
+//
+// $bg - Default: $progress-meter-color || $primary-color
+@mixin progress-meter($bg:$progress-meter-color) {
+  background: $bg;
+  display: block;
+  height: 100%;
+  float: left;
+  width: 0%;
+}
+
+
+@include exports("progress-bar") {
+  @if $include-html-media-classes {
+
+    /* Progress Bar */
+    .progress {
+      @include progress-container;
+
+      // Meter
+      .meter {
+        @include progress-meter;
+
+        &.secondary { @include progress-meter($bg:$progress-meter-secondary-color); }
+        &.success { @include progress-meter($bg:$progress-meter-success-color); }
+        &.alert { @include progress-meter($bg:$progress-meter-alert-color); }
+      }
+      &.secondary .meter { @include progress-meter($bg:$progress-meter-secondary-color); }
+      &.success .meter { @include progress-meter($bg:$progress-meter-success-color); }
+      &.alert .meter { @include progress-meter($bg:$progress-meter-alert-color); }
+
+      &.radius { @include radius($progress-bar-border-radius);
+        .meter { @include radius($progress-bar-border-radius - 1); }
+      }
+
+      &.round { @include radius(1000px);
+        .meter { @include radius(999px); }
+      }
+
+    }
+
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_range-slider.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_range-slider.scss
@@ -1,0 +1,177 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @name _range-slider.scss
+// @dependencies _global.scss
+//
+
+//
+// @variables
+//
+
+$include-html-range-slider-classes: $include-html-classes !default;
+
+// These variables define the slider bar styles
+$range-slider-bar-width: 100% !default;
+$range-slider-bar-height: rem-calc(16) !default;
+
+$range-slider-bar-border-width: 1px !default;
+$range-slider-bar-border-style: solid !default;
+$range-slider-bar-border-color: $gainsboro !default;
+$range-slider-radius: $global-radius !default;
+$range-slider-round: $global-rounded !default;
+$range-slider-bar-bg-color: $ghost !default;
+$range-slider-active-segment-bg-color: scale-color($secondary-color, $lightness: -1%) !default;
+
+// Vertical bar styles
+$range-slider-vertical-bar-width: rem-calc(16) !default;
+$range-slider-vertical-bar-height: rem-calc(200) !default;
+
+// These variables define the slider handle styles
+$range-slider-handle-width: rem-calc(32) !default;
+$range-slider-handle-height: rem-calc(22) !default;
+$range-slider-handle-position-top: rem-calc(-5) !default;
+$range-slider-handle-bg-color: $primary-color !default;
+$range-slider-handle-border-width: 1px !default;
+$range-slider-handle-border-style: solid !default;
+$range-slider-handle-border-color: none !default;
+$range-slider-handle-radius: $global-radius !default;
+$range-slider-handle-round: $global-rounded !default;
+$range-slider-handle-bg-hover-color: scale-color($primary-color, $lightness: -12%) !default;
+$range-slider-handle-cursor: pointer !default;
+
+$range-slider-disabled-opacity: .7 !default;
+$range-slider-disabled-cursor: $cursor-disabled-value !default;
+
+//
+// @mixins
+//
+
+@mixin range-slider-bar-base($vertical: false) {
+  border: $range-slider-bar-border-width $range-slider-bar-border-style $range-slider-bar-border-color;
+  margin: rem-calc(20 0);
+  position: relative;
+  -ms-touch-action: none;
+  touch-action: none;
+  @if $vertical == true {
+    display: inline-block;
+    height: $range-slider-vertical-bar-height;
+    width: $range-slider-vertical-bar-width;
+  } @else {
+    display: block;
+    height: $range-slider-bar-height;
+    width: $range-slider-bar-width;
+  }
+}
+@mixin range-slider-bar-style(
+  $bg: true,
+  $radius: false,
+  $round: false,
+  $disabled: false) {
+  @if $bg == true { background: $range-slider-bar-bg-color; }
+  @if $radius == true { @include radius($range-slider-radius); }
+  @if $round == true { @include radius($range-slider-round); }
+  @if $disabled == true {
+    cursor: $range-slider-disabled-cursor;
+    opacity: $range-slider-disabled-opacity;
+  }
+}
+
+@mixin range-slider-bar(
+  $bg: $range-slider-bar-bg-color,
+  $radius:false) {
+  @include range-slider-bar-base;
+  @include range-slider-bar-style;
+}
+
+@mixin range-slider-handle-base() {
+  border: $range-slider-handle-border-width $range-slider-handle-border-style $range-slider-handle-border-color;
+  cursor: $range-slider-handle-cursor;
+  display: inline-block;
+  height: $range-slider-handle-height;
+  position: absolute;
+  top: $range-slider-handle-position-top;
+  width: $range-slider-handle-width;
+  z-index: 1;
+
+  // This removes the 300ms touch delay on Windows 8
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+}
+
+@mixin range-slider-handle-style(
+  $bg: true,
+  $radius: false,
+  $round: false,
+  $disabled: false) {
+  @if $bg == true { background: $range-slider-handle-bg-color; }
+  @if $radius == true { @include radius($range-slider-radius); }
+  @if $round == true { @include radius($range-slider-round); }
+  @if $disabled == true {
+    cursor: $cursor-default-value;
+    opacity: $range-slider-disabled-opacity;
+  }
+  &:hover {
+    background: $range-slider-handle-bg-hover-color;
+  }
+}
+
+@mixin range-slider-handle() {
+  @include range-slider-handle-base;
+  @include range-slider-handle-style;
+}
+
+// CSS Generation
+@include exports("range-slider-bar") {
+  @if $include-html-range-slider-classes {
+    .range-slider {
+      @include range-slider-bar-base;
+      @include range-slider-bar-style($bg:true, $radius:false);
+      &.vertical-range {
+        @include range-slider-bar-base($vertical: true);
+        .range-slider-handle {
+          bottom: -($range-slider-vertical-bar-height - $range-slider-handle-width);
+          margin-#{$default-float}: -($range-slider-handle-width / 4);
+          margin-top: 0;
+          position: absolute;
+        }
+        .range-slider-active-segment {
+          border-bottom-left-radius: inherit;
+          border-bottom-right-radius: inherit;
+          border-top-left-radius: initial;
+          bottom: 0;
+          height: auto;
+          width: $range-slider-bar-height - rem-calc((strip-unit($range-slider-bar-border-width) * 2));
+        }
+      }
+      &.radius {
+        @include range-slider-bar-style($radius:true);
+        .range-slider-handle { @include range-slider-handle-style($radius: true); }
+      }
+      &.round {
+        @include range-slider-bar-style($round:true);
+        .range-slider-handle { @include range-slider-handle-style($round: true); }
+      }
+      &.disabled, &[disabled] {
+        @include range-slider-bar-style($disabled:true);
+        .range-slider-handle { @include range-slider-handle-style($disabled: true); }
+      }
+    }
+    .range-slider-active-segment {
+      background: $range-slider-active-segment-bg-color;
+      border-bottom-left-radius: inherit;
+      border-top-left-radius: inherit;
+      display: inline-block;
+      height: $range-slider-bar-height - rem-calc((strip-unit($range-slider-bar-border-width) * 2));
+      position: absolute;
+    }
+    .range-slider-handle {
+      @include range-slider-handle-base;
+      @include range-slider-handle-style($bg:true, $radius: false);
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_reveal.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_reveal.scss
@@ -1,0 +1,209 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+@import 'grid';
+
+//
+// @name _reveal.scss
+// @dependencies _global.scss
+//
+
+$include-html-reveal-classes: $include-html-classes !default;
+
+// We use these to control the style of the reveal overlay.
+$reveal-overlay-bg: rgba($black, .45) !default;
+$reveal-overlay-bg-old: $black !default;
+
+// We use these to control the style of the modal itself.
+$reveal-modal-bg: $white !default;
+$reveal-position-top: rem-calc(100) !default;
+$reveal-default-width: 80% !default;
+$reveal-max-width: $row-width !default;
+$reveal-modal-padding: rem-calc(30) !default;
+$reveal-box-shadow: 0 0 10px rgba($black,.4) !default;
+
+// We use these to style the reveal close button
+$reveal-close-font-size: rem-calc(40) !default;
+$reveal-close-top: rem-calc(10) !default;
+$reveal-close-side: rem-calc(22) !default;
+$reveal-close-color: $base !default;
+$reveal-close-weight: $font-weight-bold !default;
+
+// We use this to set the default radius used throughout the core.
+$reveal-radius: $global-radius !default;
+$reveal-round: $global-rounded !default;
+
+// We use these to control the modal border
+$reveal-border-style: solid !default;
+$reveal-border-width: 1px !default;
+$reveal-border-color: $steel !default;
+
+$reveal-modal-class: "reveal-modal" !default;
+$close-reveal-modal-class: "close-reveal-modal" !default;
+
+// Set base z-index
+$z-index-base: 1005;
+
+//
+// @mixins
+//
+
+// We use this to create the reveal background overlay styles
+@mixin reveal-bg( $include-z-index-value: true ) {
+  // position: absolute; // allows modal background to extend beyond window position
+  background: $reveal-overlay-bg-old; // Autoprefixer should be used to avoid such variables needed when Foundation for Sites can do so in the near future.
+  background: $reveal-overlay-bg;
+  bottom: 0;
+  display: none;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: if( $include-z-index-value, $z-index-base - 1, auto );
+  #{$default-float}: 0;
+}
+
+// We use this mixin to create the structure of a reveal modal
+//
+// $base-style - Provides reveal base styles, can be set to false to override. Default: true, Options: false
+// $width - Sets reveal width Default: $reveal-default-width || 80%
+//
+@mixin reveal-modal-base( $base-style: true, $width:$reveal-default-width, $max-width:$reveal-max-width, $border-radius: $reveal-radius) {
+  @if $base-style {
+    border-radius: $border-radius;
+    display: none;
+    position: absolute;
+    top:0;
+    visibility: hidden;
+    width: 100%;
+    z-index: $z-index-base;
+    #{$default-float}: 0;
+
+    @media #{$small-only} {
+      min-height:100vh;
+    }
+
+    // Make sure rows don't have a min-width on them
+    .column, .columns { min-width: 0; }
+
+    // Get rid of margin from first and last element inside modal
+    > :first-child { margin-top: 0; }
+
+    > :last-child { margin-bottom: 0; }
+  }
+
+  @if $width {
+    @media #{$medium-up} {
+      left: 0;
+      margin: 0 auto;
+      max-width: $max-width;
+      right: 0;
+      width: $width;
+    }
+  }
+}
+
+// We use this to style the reveal modal defaults
+//
+// $bg - Sets background color of reveal modal. Default: $reveal-modal-bg || $white
+// $padding - Padding to apply to reveal modal. Default: $reveal-modal-padding.
+// $border - Choose whether reveal uses a border. Default: true, Options: false
+// $border-style - Set reveal border style. Default: $reveal-border-style || solid
+// $border-width - Width of border (i.e. 1px). Default: $reveal-border-width.
+// $border-color - Color of border. Default: $reveal-border-color.
+// $box-shadow - Choose whether or not to include the default box-shadow. Default: true, Options: false
+// $radius - If true, set to modal radius which is $global-radius || explicitly set radius amount in px (ex. $radius:10px). Default: false
+// $top-offset - Default: $reveal-position-top || 50px
+@mixin reveal-modal-style(
+  $bg:false,
+  $padding:false,
+  $border:false,
+  $border-style:$reveal-border-style,
+  $border-width:$reveal-border-width,
+  $border-color:$reveal-border-color,
+  $box-shadow:false,
+  $radius:false,
+  $top-offset:false) {
+
+  @if $bg { background-color: $bg; }
+  @if $padding != false { padding: $padding; }
+
+  @if $border { border: $border-style $border-width $border-color; }
+
+  // We can choose whether or not to include the default box-shadow.
+  @if $box-shadow {
+    box-shadow: $reveal-box-shadow;
+  }
+
+  // We can control how much radius is used on the modal
+  @if $radius == true { @include radius($reveal-radius); }
+  @else if $radius { @include radius($radius); }
+
+  @if $top-offset {
+    @media #{$medium-up} {
+      top: $top-offset;
+    }
+  }
+}
+
+// We use this to create a close button for the reveal modal
+//
+// $color - Default: $reveal-close-color || $base
+@mixin reveal-close($color:$reveal-close-color) {
+  color: $color;
+  cursor: $cursor-pointer-value;
+  font-size: $reveal-close-font-size;
+  font-weight: $reveal-close-weight;
+  line-height: 1;
+  position: absolute;
+  top: $reveal-close-top;
+  #{$opposite-direction}: $reveal-close-side;
+}
+
+@include exports("reveal") {
+  @if $include-html-reveal-classes {
+
+    // Reveal Modals
+    .reveal-modal-bg { @include reveal-bg; }
+
+    .#{$reveal-modal-class} {
+      @include reveal-modal-base;
+      @include reveal-modal-style(
+        $bg:$reveal-modal-bg,
+        $padding:$reveal-modal-padding,
+        $border:true,
+        $box-shadow:true,
+        $radius:false,
+        $top-offset:$reveal-position-top
+      );
+
+      &.radius { @include reveal-modal-style($radius:true); }
+      &.round  { @include reveal-modal-style($radius:$reveal-round); }
+      &.collapse { @include reveal-modal-style($padding:0); }
+      &.tiny  { @include reveal-modal-base(false, 30%); }
+      &.small { @include reveal-modal-base(false, 40%); }
+      &.medium  { @include reveal-modal-base(false, 60%); }
+      &.large { @include reveal-modal-base(false, 70%); }
+      &.xlarge { @include reveal-modal-base(false, 95%); }
+      &.full {
+        @include reveal-modal-base(false, 100%);
+        height: 100vh;
+        height:100%;
+        left:0;
+        margin-left: 0 !important;
+        max-width: none !important;
+        min-height:100vh;
+        top:0;
+      }
+
+      // Modals pushed to back
+      &.toback {
+        z-index: $z-index-base - 2;
+      }
+
+      .#{$close-reveal-modal-class} { @include reveal-close; }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_side-nav.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_side-nav.scss
@@ -1,0 +1,120 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @variables
+//
+
+$include-html-nav-classes: $include-html-classes !default;
+
+// We use this to control padding.
+$side-nav-padding: rem-calc(14 0) !default;
+
+// We use these to control list styles.
+$side-nav-list-type: none !default;
+$side-nav-list-position: outside !default;
+$side-nav-list-margin: rem-calc(0 0 7 0) !default;
+
+// We use these to control link styles.
+$side-nav-link-color: $primary-color !default;
+$side-nav-link-color-active: scale-color($side-nav-link-color, $lightness: 30%) !default;
+$side-nav-link-color-hover: scale-color($side-nav-link-color, $lightness: 30%) !default;
+$side-nav-link-bg-hover: hsla(0, 0, 0, .025) !default;
+$side-nav-link-margin: 0 !default;
+$side-nav-link-padding: rem-calc(7 14) !default;
+$side-nav-font-size: rem-calc(14) !default;
+$side-nav-font-weight: $font-weight-normal !default;
+$side-nav-font-weight-active: $side-nav-font-weight !default;
+$side-nav-font-family: $body-font-family !default;
+$side-nav-font-family-active: $side-nav-font-family !default;
+
+// We use these to control heading styles.
+$side-nav-heading-color: $side-nav-link-color !default;
+$side-nav-heading-font-size: $side-nav-font-size !default;
+$side-nav-heading-font-weight: bold !default;
+$side-nav-heading-text-transform: uppercase !default;
+
+// We use these to control border styles
+$side-nav-divider-size: 1px !default;
+$side-nav-divider-style: solid !default;
+$side-nav-divider-color: scale-color($white, $lightness: -10%) !default;
+
+
+//
+// @mixins
+//
+
+
+// We use this to style the side-nav
+//
+// $divider-color - Border color of divider. Default: $side-nav-divider-color.
+// $font-size - Font size of nav items. Default: $side-nav-font-size.
+// $link-color - Color of navigation links. Default: $side-nav-link-color.
+// $link-color-hover - Color of navigation links when hovered. Default: $side-nav-link-color-hover.
+@mixin side-nav(
+  $divider-color:$side-nav-divider-color,
+  $font-size:$side-nav-font-size,
+  $link-color:$side-nav-link-color,
+  $link-color-active:$side-nav-link-color-active,
+  $link-color-hover:$side-nav-link-color-hover,
+  $link-bg-hover:$side-nav-link-bg-hover) {
+  display: block;
+  font-family: $side-nav-font-family;
+  list-style-position: $side-nav-list-position;
+  list-style-type: $side-nav-list-type;
+  margin: 0;
+  padding: $side-nav-padding;
+
+  li {
+    font-size: $font-size;
+    font-weight: $side-nav-font-weight;
+    margin: $side-nav-list-margin;
+
+    a:not(.button) {
+      color: $link-color;
+      display: block;
+      margin: $side-nav-link-margin;
+      padding: $side-nav-link-padding;
+      &:hover,
+      &:focus {
+        background: $link-bg-hover;
+        color: $link-color-hover;
+      }
+      &:active {
+        color: $link-color-active;
+      }
+    }
+
+    &.active > a:first-child:not(.button) {
+      color: $side-nav-link-color-active;
+      font-family: $side-nav-font-family-active;
+      font-weight: $side-nav-font-weight-active;
+    }
+
+    &.divider {
+      border-top: $side-nav-divider-size $side-nav-divider-style;
+      height: 0;
+      list-style: none;
+      padding: 0;
+      border-top-color: $divider-color;
+    }
+
+    &.heading {
+      color: $side-nav-heading-color;
+      font: {
+        size: $side-nav-heading-font-size;
+        weight: $side-nav-heading-font-weight;
+      }
+      text-transform: $side-nav-heading-text-transform;
+    }
+  }
+}
+
+@include exports("side-nav") {
+  @if $include-html-nav-classes {
+    .side-nav {@include side-nav;}
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_split-buttons.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_split-buttons.scss
@@ -1,0 +1,203 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+@import 'buttons';
+@import 'dropdown-buttons';
+
+//
+// @name _split-buttons.scss
+// @dependencies _buttons.scss, _global.scss
+//
+
+//
+// @variables
+//
+
+$include-html-button-classes: $include-html-classes !default;
+
+// We use these to control different shared styles for Split Buttons
+$split-button-function-factor: 10% !default;
+$split-button-pip-color: $white !default;
+$split-button-pip-color-alt: $oil !default;
+$split-button-active-bg-tint: rgba(0,0,0,0.1) !default;
+$split-button-span-border-color: rgba(255,255,255,0.5) !default;
+
+// We use these to control tiny split buttons
+$split-button-padding-tny: $button-pip-tny * 10 !default;
+$split-button-span-width-tny: $button-pip-tny * 6 !default;
+$split-button-pip-size-tny: $button-pip-tny !default;
+$split-button-pip-top-tny: $button-pip-tny * 2 !default;
+$split-button-pip-default-float-tny: rem-calc(-6) !default;
+
+// We use these to control small split buttons
+$split-button-padding-sml: $button-pip-sml * 10 !default;
+$split-button-span-width-sml: $button-pip-sml * 6 !default;
+$split-button-pip-size-sml: $button-pip-sml !default;
+$split-button-pip-top-sml: $button-pip-sml * 1.5 !default;
+$split-button-pip-default-float-sml: rem-calc(-6) !default;
+
+// We use these to control medium split buttons
+$split-button-padding-med: $button-pip-med * 9 !default;
+$split-button-span-width-med: $button-pip-med * 5.5 !default;
+$split-button-pip-size-med: $button-pip-med - rem-calc(3) !default;
+$split-button-pip-top-med: $button-pip-med * 1.5 !default;
+$split-button-pip-default-float-med: rem-calc(-6) !default;
+
+// We use these to control large split buttons
+$split-button-padding-lrg: $button-pip-lrg * 8 !default;
+$split-button-span-width-lrg: $button-pip-lrg * 5 !default;
+$split-button-pip-size-lrg: $button-pip-lrg - rem-calc(6) !default;
+$split-button-pip-top-lrg: $button-pip-lrg + rem-calc(5) !default;
+$split-button-pip-default-float-lrg: rem-calc(-6) !default;
+
+
+//
+// @mixins
+//
+
+// We use this mixin to create split buttons that build upon the button mixins
+//
+// $padding - Type of padding to apply. Default: medium. Options: tiny, small, medium, large.
+// $pip-color - Color of the triangle. Default: $split-button-pip-color.
+// $span-border - Border color of button divider. Default: $split-button-span-border-color.
+// $base-style - Apply base style to split button. Default: true.
+@mixin split-button(
+  $padding:medium,
+  $pip-color:$split-button-pip-color,
+  $span-border:$split-button-span-border-color,
+  $base-style:true) {
+
+  // With this, we can control whether or not the base styles come through.
+  @if $base-style {
+    position: relative;
+
+    // Styling for the split arrow clickable area
+    span {
+      display: block;
+      height: 100%;
+      position: absolute;
+      #{$opposite-direction}: 0;
+      top: 0;
+      border-#{$default-float}: solid 1px;
+
+      // Building the triangle pip indicator
+      &:after {
+        position: absolute;
+        content: "";
+        width: 0;
+        height: 0;
+        display: block;
+        border-style: inset;
+        top: 50%;
+        #{$default-float}: 50%;
+      }
+
+      &:active { background-color: $split-button-active-bg-tint; }
+    }
+  }
+
+  // Control the border color for the span area of the split button
+  @if $span-border {
+    span {
+      border-#{$default-float}-color: $span-border;
+    }
+  }
+
+  // Style of the button and clickable area for tiny sizes
+  @if $padding == tiny {
+    padding-#{$opposite-direction}: $split-button-padding-tny;
+
+    span { width: $split-button-span-width-tny;
+      &:after {
+        border-top-style: solid;
+        border-width: $split-button-pip-size-tny;
+        margin-#{$default-float}: $split-button-pip-default-float-tny;
+        top: 48%;
+      }
+    }
+  }
+
+  // Style of the button and clickable area for small sizes
+  @else if $padding == small {
+    padding-#{$opposite-direction}: $split-button-padding-sml;
+
+    span { width: $split-button-span-width-sml;
+      &:after {
+        border-top-style: solid;
+        border-width: $split-button-pip-size-sml;
+        margin-#{$default-float}: $split-button-pip-default-float-sml;
+        top: 48%;
+      }
+    }
+  }
+
+  // Style of the button and clickable area for default (medium) sizes
+  @else if $padding == medium {
+    padding-#{$opposite-direction}: $split-button-padding-med;
+
+    span { width: $split-button-span-width-med;
+      &:after {
+        border-top-style: solid;
+        border-width: $split-button-pip-size-med;
+        margin-#{$default-float}: $split-button-pip-default-float-med;
+        top: 48%;
+      }
+    }
+  }
+
+  // Style of the button and clickable area for large sizes
+  @else if $padding == large {
+    padding-#{$opposite-direction}: $split-button-padding-lrg;
+
+    span { width: $split-button-span-width-lrg;
+      &:after {
+        border-top-style: solid;
+        border-width: $split-button-pip-size-lrg;
+        margin-#{$default-float}: $split-button-pip-default-float-lrg;
+        top: 48%;
+      }
+    }
+  }
+
+  // Control the color of the triangle pip
+  @if $pip-color {
+    span:after { border-color: $pip-color transparent transparent transparent; }
+  }
+}
+
+@include exports("split-button") {
+  @if $include-html-button-classes {
+
+    .split.button { @include split-button;
+
+      &.secondary { @include split-button(false, $split-button-pip-color, $split-button-span-border-color, false); }
+      &.alert { @include split-button(false, false, $split-button-span-border-color, false); }
+      &.success { @include split-button(false, false, $split-button-span-border-color, false); }
+
+      &.tiny { @include split-button(tiny, false, false, false); }
+      &.small { @include split-button(small, false, false, false); }
+      &.large { @include split-button(large, false, false, false); }
+      &.expand { padding-left: px(2rem); }
+
+      &.secondary { @include split-button(false, $split-button-pip-color-alt, false, false); }
+
+      &.radius span { @include side-radius($opposite-direction, $global-radius); }
+      &.round span { @include side-radius($opposite-direction, 1000px); }
+      &.no-pip{
+        span:before{ border-style:none; }
+        span:after{ border-style:none; }
+        span>i{
+          display: block;
+          left: 50%;
+          margin-left: -0.28889em;
+          margin-top: -0.48889em;
+          position: absolute;
+          top: 50%;
+        }
+      }
+    }
+
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_sub-nav.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_sub-nav.scss
@@ -1,0 +1,125 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @name _sub-nav.scss
+// @dependencies _global.scss
+//
+
+//
+// @variables
+//
+
+$include-html-nav-classes: $include-html-classes !default;
+
+// We use these to control margin and padding
+$sub-nav-list-margin: rem-calc(-4 0 18) !default;
+$sub-nav-list-padding-top: rem-calc(4) !default;
+
+// We use this to control the definition
+$sub-nav-font-family: $body-font-family !default;
+$sub-nav-font-size: rem-calc(14) !default;
+$sub-nav-font-color: $aluminum !default;
+$sub-nav-font-weight: $font-weight-normal !default;
+$sub-nav-text-decoration: none !default;
+$sub-nav-padding: rem-calc(3 16) !default;
+$sub-nav-border-radius: 3px !default;
+$sub-nav-font-color-hover: scale-color($sub-nav-font-color, $lightness: -25%) !default;
+
+
+// We use these to control the active item styles
+
+$sub-nav-active-font-weight: $font-weight-normal !default;
+$sub-nav-active-bg: $primary-color !default;
+$sub-nav-active-bg-hover: scale-color($sub-nav-active-bg, $lightness: -14%) !default;
+$sub-nav-active-color: $white !default;
+$sub-nav-active-padding: $sub-nav-padding !default;
+$sub-nav-active-cursor: default !default;
+
+$sub-nav-item-divider: "" !default;
+$sub-nav-item-divider-margin: rem-calc(12) !default;
+
+//
+// @mixins
+//
+
+
+// Create a sub-nav item
+//
+// $font-color - Font color. Default: $sub-nav-font-color.
+// $font-size - Font size. Default: $sub-nav-font-size.
+// $active-bg - Background of active nav item. Default: $sub-nav-active-bg.
+// $active-bg-hover - Background of active nav item, when hovered. Default: $sub-nav-active-bg-hover.
+@mixin sub-nav(
+  $font-color: $sub-nav-font-color,
+  $font-size: $sub-nav-font-size,
+  $active-bg: $sub-nav-active-bg,
+  $active-bg-hover: $sub-nav-active-bg-hover) {
+  display: block;
+  margin: $sub-nav-list-margin;
+  overflow: hidden;
+  padding-top: $sub-nav-list-padding-top;
+  width: auto;
+
+  dt {
+    text-transform: uppercase;
+  }
+
+  dt,
+  dd,
+  li {
+    color: $font-color;
+    float: $default-float;
+    font-family: $sub-nav-font-family;
+    font-size: $font-size;
+    font-weight: $sub-nav-font-weight;
+    margin-#{$default-float}: rem-calc(16);
+    margin-bottom: 0;
+
+    a {
+      color: $sub-nav-font-color;
+      padding: $sub-nav-padding;
+      text-decoration: $sub-nav-text-decoration;
+
+      &:hover {
+        color: $sub-nav-font-color-hover;
+      }
+    }
+
+    &.active a {
+      @include radius($sub-nav-border-radius);
+      background: $active-bg;
+      color: $sub-nav-active-color;
+      cursor: $sub-nav-active-cursor;
+      font-weight: $sub-nav-active-font-weight;
+      padding: $sub-nav-active-padding;
+
+      &:hover {
+        background: $active-bg-hover;
+      }
+    }
+
+    @if $sub-nav-item-divider != "" {
+      margin-#{$default-float}: 0;
+
+      &:before {
+        content: "#{$sub-nav-item-divider}";
+        margin: 0 $sub-nav-item-divider-margin;
+      }
+
+      &:first-child:before {
+        content: "";
+        margin: 0;
+      }
+    }
+  }
+}
+
+@include exports("sub-nav") {
+  @if $include-html-nav-classes {
+    .sub-nav { @include sub-nav; }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_switches.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_switches.scss
@@ -1,0 +1,241 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @name
+// @dependencies _global.scss
+//
+
+//
+// @variables
+//
+
+$include-html-form-classes: $include-html-classes !default;
+
+// Controlling background color for the switch container
+$switch-bg: $gainsboro !default;
+
+// We use these to control the switch heights for our default classes
+$switch-height-tny: px(1.5rem) !default;
+$switch-height-sml: px(1.75rem) !default;
+$switch-height-med: px(2rem) !default;
+$switch-height-lrg: px(2.5rem) !default;
+$switch-bottom-margin: px(1.5rem) !default;
+
+// We use these to style the switch-paddle
+$switch-paddle-bg: $white !default;
+$switch-paddle-transition-speed: .15s !default;
+$switch-paddle-transition-ease: ease-out !default;
+$switch-active-color: $primary-color !default;
+
+
+//
+// @mixins
+//
+
+// We use this mixin to create the base styles for our switch element.
+//
+// $transition-speed - Time in ms for switch to toggle. Default: $switch-paddle-transition-speed.
+// $transition-ease - Easing function to use for animation (i.e. ease-out). Default: $switch-paddle-transition-ease.
+@mixin switch-base(
+  $transition-speed:$switch-paddle-transition-speed,
+  $transition-ease:$switch-paddle-transition-ease) {
+
+  border: none;
+  margin-bottom: $switch-bottom-margin;
+  outline: 0;
+  padding: 0;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+
+  // Default label styles for type and transition
+  label {
+    background: $switch-bg;
+    color: transparent;
+    cursor: pointer;
+    display: block;
+    margin-bottom: ($switch-height-med / 2);
+    position: relative;
+    text-indent: 100%;
+    width: $switch-height-med * 2; height: $switch-height-med;
+
+    // Transition for the switch label to follow paddle
+    @include single-transition(left, $transition-speed, $transition-ease);
+  }
+
+  // So that we don't need to recreate the form with any JS, we use the
+  // existing checkbox or radio button, but we cleverly position and hide it.
+  input {
+    left: 10px;
+    opacity: 0;
+    padding:0;
+    position: absolute;
+    top: 9px;
+
+    & + label { margin-left: 0; margin-right: 0; }
+  }
+
+  // The paddle for the switch is created from an after psuedoclass
+  // content element. This is sized and positioned, and reacts to
+  // the state of the input.
+
+  label:after {
+    background: $switch-paddle-bg;
+    content: "";
+    display: block;
+    height: $switch-height-med - px(.5rem);
+    left: px(.25rem);
+    position: absolute;
+    top: px(.25rem);
+    width: $switch-height-med - px(.5rem);
+
+    -webkit-transition: left $transition-speed $transition-ease;
+    -moz-transition: left $transition-speed $transition-ease;
+    -o-transition: translate3d(0,0,0);
+    transition: left $transition-speed $transition-ease;
+
+    -webkit-transform: translate3d(0,0,0);
+    -moz-transform: translate3d(0,0,0);
+    -ms-transform: translate3d(0,0,0);
+    -o-transform: translate3d(0,0,0);
+    transform: translate3d(0,0,0);
+  }
+
+  input:checked + label {
+    background: $switch-active-color;
+  }
+
+  input:checked + label:after {
+    left: $switch-height-med + px(.25rem);
+  }
+}
+
+// We use this mixin to create the size styles for switches.
+//
+// $height - Height (in px) of the switch. Default: $switch-height-med.
+// $font-size - Font size of text in switch. Default: $switch-font-size-med.
+// $line-height - Line height of switch. Default: 2.3rem.
+@mixin switch-size($height: $switch-height-med) {
+
+  label {
+    height: $height;
+    width: $height * 2;
+  }
+
+  label:after {
+    height: $height - px(.5rem);
+    width: $height - px(.5rem);
+  }
+
+  input:checked + label:after {
+    left: $height + px(.25rem);
+  }
+
+}
+
+// We use this mixin to add color and other fanciness to the switches.
+//
+// $paddle-bg - Background of switch paddle. Default: $switch-paddle-bg.
+// $active-color - Background color of positive side of switch. Default: $switch-positive-color.
+// $negative-color - Background color of negative side of switch. Default: $switch-negative-color.
+// $radius - Radius to apply to switch. Default: false.
+// $base-style - Apply base styles? Default: true.
+@mixin switch-style(
+  $paddle-bg:$switch-paddle-bg,
+  $active-color:$switch-active-color,
+  $radius:false,
+  $base-style:true) {
+
+  @if $base-style {
+
+    label {
+      color: transparent;
+      background: $switch-bg;
+    }
+
+    label:after {
+      background: $paddle-bg;
+    }
+
+    input:checked + label {
+      background: $active-color;
+    }
+  }
+
+  // Setting up the radius for switches
+  @if $radius == true {
+    label {
+      border-radius: px(2rem);
+    }
+    label:after {
+      border-radius: px(2rem);
+    }
+  }
+  @else if $radius {
+    label {
+      border-radius: $radius;
+    }
+    label:after {
+      border-radius: $radius;
+    }
+  }
+
+}
+
+// We use this to quickly create switches with a single mixin
+//
+// $transition-speed - Time in ms for switch to toggle. Default: $switch-paddle-transition-speed.
+// $transition-ease - Easing function to use for animation (i.e. ease-out). Default: $switch-paddle-transition-ease.
+// $height - Height (in px) of the switch. Default: $switch-height-med.
+// $paddle-bg - Background of switch paddle. Default: $switch-paddle-bg.
+// $active-color - Background color of an active switch. Default: $switch-active-color.
+// $radius - Radius to apply to switch. Default: false.
+// $base-style - Apply base styles? Default: true.
+@mixin switch(
+  $transition-speed: $switch-paddle-transition-speed,
+  $transition-ease: $switch-paddle-transition-ease,
+  $height: $switch-height-med,
+  $paddle-bg: $switch-paddle-bg,
+  $active-color: $switch-active-color,
+  $radius:false,
+  $base-style:true) {
+    @include switch-base($transition-speed, $transition-ease);
+    @include switch-size($height);
+    @include switch-style($paddle-bg, $active-color, $radius, $base-style);
+}
+
+@include exports("switch") {
+  @if $include-html-form-classes {
+      .switch {
+        @include switch;
+
+        // Large radio switches
+        &.large { @include switch-size($switch-height-lrg); }
+
+        // Small radio switches
+        &.small { @include switch-size($switch-height-sml); }
+
+        // Tiny radio switches
+        &.tiny { @include switch-size($switch-height-tny); }
+
+        // Add a radius to the switch
+        &.radius {
+          label { @include radius(4px); }
+          label:after { @include radius(3px); }
+        }
+
+        // Make the switch completely round, like a pill
+        &.round { @include radius(1000px);
+          label { @include radius(px(2rem)); }
+          label:after { @include radius(px(2rem)); }
+        }
+
+      }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_tables.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_tables.scss
@@ -1,0 +1,135 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @name _tables.scss
+// @dependencies _global.scss
+//
+
+//
+// @variables
+//
+
+$include-html-table-classes: $include-html-classes !default;
+
+// These control the background color for the table and even rows
+$table-bg: $white !default;
+$table-even-row-bg: $snow !default;
+
+// These control the table cell border style
+$table-border-style: solid !default;
+$table-border-size: 1px !default;
+$table-border-color: $gainsboro !default;
+
+// These control the table head styles
+$table-head-bg: $white-smoke !default;
+$table-head-font-size: rem-calc(14) !default;
+$table-head-font-color: $jet !default;
+$table-head-font-weight: $font-weight-bold !default;
+$table-head-padding: rem-calc(8 10 10) !default;
+
+// These control the table foot styles
+$table-foot-bg: $table-head-bg !default;
+$table-foot-font-size: $table-head-font-size !default;
+$table-foot-font-color: $table-head-font-color !default;
+$table-foot-font-weight: $table-head-font-weight !default;
+$table-foot-padding: $table-head-padding !default;
+
+// These control the caption
+$table-caption-bg: transparent !default;
+$table-caption-font-color: $table-head-font-color !default;
+$table-caption-font-size: rem-calc(16) !default;
+$table-caption-font-weight: bold !default;
+
+// These control the row padding and font styles
+$table-row-padding: rem-calc(9 10) !default;
+$table-row-font-size: rem-calc(14) !default;
+$table-row-font-color: $jet !default;
+$table-line-height: rem-calc(18) !default;
+
+// These are for controlling the layout, display and margin of tables
+$table-layout: auto !default;
+$table-display: table-cell !default;
+$table-margin-bottom: rem-calc(20) !default;
+
+
+//
+// @mixins
+//
+
+@mixin table {
+  background: $table-bg;
+  border: $table-border-style $table-border-size $table-border-color;
+  margin-bottom: $table-margin-bottom;
+  table-layout: $table-layout;
+
+  caption {
+    background: $table-caption-bg;
+    color: $table-caption-font-color;
+    font: {
+      size: $table-caption-font-size;
+      weight: $table-caption-font-weight;
+    }
+  }
+
+  thead {
+    background: $table-head-bg;
+
+    tr {
+      th,
+      td {
+        color: $table-head-font-color;
+        font-size: $table-head-font-size;
+        font-weight: $table-head-font-weight;
+        padding: $table-head-padding;
+      }
+    }
+  }
+
+  tfoot {
+    background: $table-foot-bg;
+
+    tr {
+      th,
+      td {
+        color: $table-foot-font-color;
+        font-size: $table-foot-font-size;
+        font-weight: $table-foot-font-weight;
+        padding: $table-foot-padding;
+      }
+    }
+  }
+
+  tr {
+    th,
+    td {
+      color: $table-row-font-color;
+      font-size: $table-row-font-size;
+      padding: $table-row-padding;
+      text-align: $default-float;
+    }
+
+    &.even,
+    &.alt,
+    &:nth-of-type(even) { background: $table-even-row-bg; }
+  }
+
+  thead tr th,
+  tfoot tr th,
+  tfoot tr td,
+  tbody tr th,
+  tbody tr td,
+  tr td { display: $table-display; line-height: $table-line-height; }
+}
+
+
+@include exports("table") {
+  @if $include-html-table-classes {
+    table {
+      @include table;
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_tabs.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_tabs.scss
@@ -1,0 +1,142 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+@import 'grid';
+
+//
+// @variables
+//
+
+$include-html-tabs-classes: $include-html-classes !default;
+
+$tabs-navigation-padding: rem-calc(16) !default;
+$tabs-navigation-bg-color: $silver !default;
+$tabs-navigation-active-bg-color: $white !default;
+$tabs-navigation-hover-bg-color: scale-color($tabs-navigation-bg-color, $lightness: -6%) !default;
+$tabs-navigation-font-color: $jet !default;
+$tabs-navigation-active-font-color: $tabs-navigation-font-color !default;
+$tabs-navigation-font-size: rem-calc(16) !default;
+$tabs-navigation-font-family: $body-font-family !default;
+
+$tabs-content-margin-bottom: rem-calc(24) !default;
+$tabs-content-padding: ($column-gutter/2) !default;
+
+$tabs-vertical-navigation-margin-bottom: px(1.25rem) !default;
+
+@include exports("tab") {
+  @if $include-html-tabs-classes {
+    .tabs {
+      @include clearfix;
+      margin-bottom: 0 !important;
+      margin-left: 0;
+
+      dd,
+      .tab-title {
+        float: $default-float;
+        list-style: none;
+        margin-bottom: 0 !important;
+        position: relative;
+
+        > a {
+          display: block;
+          background-color: $tabs-navigation-bg-color;
+          color: $tabs-navigation-font-color;
+          font-family: $tabs-navigation-font-family;
+          font-size: $tabs-navigation-font-size;
+          padding: $tabs-navigation-padding $tabs-navigation-padding * 2;
+
+          &:hover {
+            background-color: $tabs-navigation-hover-bg-color;
+          }
+        }
+
+        &.active a {
+          background-color: $tabs-navigation-active-bg-color;
+          color: $tabs-navigation-active-font-color;
+        }
+      }
+
+      &.radius {
+        dd:first-child,
+        .tab:first-child {
+          a { @include side-radius($default-float, $global-radius); }
+        }
+
+        dd:last-child,
+        .tab:last-child {
+          a { @include side-radius($opposite-direction, $global-radius); }
+        }
+      }
+
+      &.vertical {
+        dd,
+        .tab-title {
+          position: inherit;
+          float: none;
+          display: block;
+          top: auto;
+        }
+      }
+    }
+
+    .tabs-content {
+      @include clearfix;
+      margin-bottom: $tabs-content-margin-bottom;
+      width: 100%;
+
+      > .content {
+        display: none;
+        float: $default-float;
+        padding: $tabs-content-padding 0;
+        width: 100%;
+
+        &.active {
+          display: block;
+          float: none;
+        }
+        &.contained {
+          padding: $tabs-content-padding;
+        }
+      }
+
+      &.vertical {
+        display: block;
+
+        > .content {
+          padding: 0 $tabs-content-padding;
+        }
+      }
+    }
+
+    @media #{$medium-up} {
+      .tabs {
+        &.vertical {
+          float: $default-float;
+          margin: 0;
+          margin-bottom: $tabs-vertical-navigation-margin-bottom !important;
+          max-width: 20%;
+          width: 20%;
+        }
+      }
+
+      .tabs-content {
+        &.vertical {
+          float: $default-float;
+          margin-#{$default-float}: -1px;
+          max-width: 80%;
+          padding-#{$default-float}: px(1rem);
+          width: 80%;
+        }
+      }
+    }
+
+    .no-js {
+      .tabs-content > .content {
+        display: block;
+        float: none;
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_thumbs.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_thumbs.scss
@@ -1,0 +1,66 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// @name _thumbs.scss
+// @dependencies _globals.scss
+//
+
+//
+// @variables
+//
+
+$include-html-media-classes: $include-html-classes !default;
+
+// We use these to control border styles
+$thumb-border-style: solid !default;
+$thumb-border-width: 4px !default;
+$thumb-border-color: $white !default;
+$thumb-box-shadow: 0 0 0 1px rgba($black,.2) !default;
+$thumb-box-shadow-hover: 0 0 6px 1px rgba($primary-color,0.5) !default;
+
+// Radius and transition speed for thumbs
+$thumb-radius: $global-radius !default;
+$thumb-transition-speed: 200ms !default;
+
+//
+// @mixins
+//
+
+// We use this to create image thumbnail styles.
+//
+// $border-width - Width of border around thumbnail. Default: $thumb-border-width.
+// $box-shadow - Box shadow to apply to thumbnail. Default: $thumb-box-shadow.
+// $box-shadow-hover - Box shadow to apply on hover. Default: $thumb-box-shadow-hover.
+@mixin thumb(
+  $border-width:$thumb-border-width,
+  $box-shadow:$thumb-box-shadow,
+  $box-shadow-hover:$thumb-box-shadow-hover) {
+  border: $thumb-border-style $border-width $thumb-border-color;
+  box-shadow: $box-shadow;
+  display: inline-block;
+  line-height: 0;
+  max-width: 100%;
+
+  &:hover,
+  &:focus {
+    box-shadow: $box-shadow-hover;
+  }
+}
+
+
+@include exports("thumb") {
+  @if $include-html-media-classes {
+
+    /* Image Thumbnails */
+    .th {
+      @include thumb;
+      @include single-transition(all, $thumb-transition-speed, ease-out);
+
+      &.radius { @include radius($thumb-radius); }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_tooltips.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_tooltips.scss
@@ -1,0 +1,142 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// Tooltip Variables
+//
+$include-html-tooltip-classes: $include-html-classes !default;
+
+$has-tip-border-bottom: dotted 1px $iron !default;
+$has-tip-font-weight: $font-weight-bold !default;
+$has-tip-font-color: $oil !default;
+$has-tip-border-bottom-hover: dotted 1px scale-color($primary-color, $lightness: -55%) !default;
+$has-tip-font-color-hover: $primary-color !default;
+$has-tip-cursor-type: help !default;
+
+$tooltip-padding: rem-calc(12) !default;
+$tooltip-bg: $oil !default;
+$tooltip-font-size: rem-calc(14) !default;
+$tooltip-font-weight: $font-weight-normal !default;
+$tooltip-font-color: $white !default;
+$tooltip-line-height: 1.3 !default;
+$tooltip-close-font-size: rem-calc(10) !default;
+$tooltip-close-font-weight: $font-weight-normal !default;
+$tooltip-close-font-color: $monsoon !default;
+$tooltip-font-size-sml: rem-calc(14) !default;
+$tooltip-radius: $global-radius !default;
+$tooltip-rounded: $global-rounded !default;
+$tooltip-pip-size: 5px !default;
+$tooltip-max-width: 300px !default;
+
+@include exports("tooltip") {
+  @if $include-html-tooltip-classes {
+
+    /* Tooltips */
+    .has-tip {
+      border-bottom: $has-tip-border-bottom;
+      color: $has-tip-font-color;
+      cursor: $has-tip-cursor-type;
+      font-weight: $has-tip-font-weight;
+
+      &:hover,
+      &:focus {
+        border-bottom: $has-tip-border-bottom-hover;
+        color: $has-tip-font-color-hover;
+      }
+
+      &.tip-left,
+      &.tip-right { float: none !important; }
+    }
+
+    .tooltip {
+      background: $tooltip-bg;
+      color: $tooltip-font-color;
+      display: none;
+      font-size: $tooltip-font-size;
+      font-weight: $tooltip-font-weight;
+      line-height: $tooltip-line-height;
+      max-width: $tooltip-max-width;
+      padding: $tooltip-padding;
+      position: absolute;
+      width: 100%;
+      z-index: 1006;
+      #{$default-float}: 50%;
+
+      > .nub {
+        border-color: transparent transparent $tooltip-bg transparent;
+        border: solid $tooltip-pip-size;
+        display: block;
+        height: 0;
+        pointer-events: none;
+        position: absolute;
+        top: -($tooltip-pip-size * 2);
+        width: 0;
+        #{$default-float}: $tooltip-pip-size;
+
+        &.rtl {
+          left: auto;
+          #{$opposite-direction}: $tooltip-pip-size;
+        }
+      }
+
+      &.radius {
+        @include radius($tooltip-radius);
+      }
+      &.round {
+        @include radius($tooltip-rounded);
+        > .nub {
+          left: px(2rem);
+        }
+      }
+
+      &.opened {
+        border-bottom: $has-tip-border-bottom-hover !important;
+        color: $has-tip-font-color-hover !important;
+      }
+    }
+
+    .tap-to-close {
+      color: $tooltip-close-font-color;
+      display: block;
+      font-size: $tooltip-close-font-size;
+      font-weight: $tooltip-close-font-weight;
+    }
+
+    @media #{$small} {
+      .tooltip {
+        > .nub {
+          border-color: transparent transparent $tooltip-bg transparent;
+          top: -($tooltip-pip-size * 2);
+        }
+        &.tip-top>.nub {
+          border-color: $tooltip-bg transparent transparent transparent;
+          bottom: -($tooltip-pip-size * 2);
+          top: auto;
+        }
+
+        &.tip-left,
+        &.tip-right { float: none !important; }
+
+        &.tip-left>.nub {
+          border-color: transparent transparent transparent $tooltip-bg;
+          left: auto;
+          margin-top: -$tooltip-pip-size;
+          right: -($tooltip-pip-size * 2);
+          top: 50%;
+        }
+        &.tip-right>.nub {
+          border-color: transparent $tooltip-bg transparent transparent;
+          left: -($tooltip-pip-size * 2);
+          margin-top: -$tooltip-pip-size;
+          right: auto;
+          top: 50%;
+        }
+
+      }
+    }
+
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_top-bar.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_top-bar.scss
@@ -1,0 +1,745 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+@import 'grid';
+@import 'buttons';
+@import 'forms';
+
+//
+// Top Bar Variables
+//
+$include-html-top-bar-classes: $include-html-classes !default;
+
+// Background color for the top bar
+$topbar-bg-color: $oil !default;
+$topbar-bg: $topbar-bg-color !default;
+
+// Height and margin
+$topbar-height: rem-calc(45) !default;
+$topbar-margin-bottom: 0 !default;
+
+// Controlling the styles for the title in the top bar
+$topbar-title-weight: $font-weight-normal !default;
+$topbar-title-font-size: rem-calc(17) !default;
+
+// Set the link colors and styles for top-level nav
+$topbar-link-color: $white !default;
+$topbar-link-color-hover: $white !default;
+$topbar-link-color-active: $white !default;
+$topbar-link-color-active-hover: $white !default;
+$topbar-link-weight: $font-weight-normal !default;
+$topbar-link-font-size: rem-calc(13) !default;
+$topbar-link-hover-lightness: -10% !default; // Darken by 10%
+$topbar-link-bg: $topbar-bg !default;
+$topbar-link-bg-hover: $jet !default;
+$topbar-link-bg-color-hover: $charcoal !default;
+$topbar-link-bg-active: $primary-color !default;
+$topbar-link-bg-active-hover: scale-color($primary-color, $lightness: -14%) !default;
+$topbar-link-font-family: $body-font-family !default;
+$topbar-link-text-transform: none !default;
+$topbar-link-padding: ($topbar-height / 3) !default;
+$topbar-back-link-size: rem-calc(18) !default;
+$topbar-link-dropdown-padding: rem-calc(20) !default;
+$topbar-button-font-size: px(.75rem) !default;
+$topbar-button-top: 7px !default;
+
+// Style the top bar dropdown elements
+$topbar-dropdown-bg: $oil !default;
+$topbar-dropdown-link-color: $white !default;
+$topbar-dropdown-link-color-hover: $topbar-link-color-hover !default;
+$topbar-dropdown-link-bg: $oil !default;
+$topbar-dropdown-link-bg-hover: $jet !default;
+$topbar-dropdown-link-weight: $font-weight-normal !default;
+$topbar-dropdown-toggle-size: 5px !default;
+$topbar-dropdown-toggle-color: $white !default;
+$topbar-dropdown-toggle-alpha: .4 !default;
+
+$topbar-dropdown-label-color: $monsoon !default;
+$topbar-dropdown-label-text-transform: uppercase !default;
+$topbar-dropdown-label-font-weight: $font-weight-bold !default;
+$topbar-dropdown-label-font-size: rem-calc(10) !default;
+$topbar-dropdown-label-bg: $oil !default;
+
+// Top menu icon styles
+$topbar-menu-link-transform: uppercase !default;
+$topbar-menu-link-font-size: rem-calc(13) !default;
+$topbar-menu-link-weight: $font-weight-bold !default;
+$topbar-menu-link-color: $white !default;
+$topbar-menu-icon-color: $white !default;
+$topbar-menu-link-color-toggled: $jumbo !default;
+$topbar-menu-icon-color-toggled: $jumbo !default;
+$topbar-menu-icon-position: $opposite-direction !default; // Change to $default-float for a left menu icon
+
+// Transitions and breakpoint styles
+$topbar-transition-speed: 300ms !default;
+// Using rem-calc for the below breakpoint causes issues with top bar
+$topbar-breakpoint: #{lower-bound($medium-range)} !default; // Change to 9999px for always mobile layout
+$topbar-media-query: "#{$screen} and (min-width:#{lower-bound($topbar-breakpoint)})" !default;
+
+// Top-bar input styles
+$topbar-input-height: rem-calc(28) !default;
+
+// Divider Styles
+$topbar-divider-border-bottom: solid 1px scale-color($topbar-bg-color, $lightness: 13%) !default;
+$topbar-divider-border-top: solid 1px scale-color($topbar-bg-color, $lightness: -50%) !default;
+
+// Sticky Class
+$topbar-sticky-class: ".sticky" !default;
+$topbar-arrows: true !default; //Set false to remove the triangle icon from the menu item
+$topbar-dropdown-arrows: true !default; //Set false to remove the \00bb >> text from dropdown subnavigation li
+
+// Accessibility mixins for hiding and showing the menu dropdown items
+@mixin topbar-hide-dropdown {
+  // Makes an element visually hidden by default, but visible when focused.
+  @include element-invisible();
+  display: block;
+}
+
+@mixin topbar-show-dropdown {
+  @include element-invisible-off();
+  display: block;
+  position: absolute !important; // Reset the position from static to absolute
+}
+
+@include exports("top-bar") {
+
+  @if $include-html-top-bar-classes {
+
+    // Used to provide media query values for javascript components.
+    // This class is generated despite the value of $include-html-top-bar-classes
+    // to ensure width calculations work correctly.
+    meta.foundation-mq-topbar {
+      font-family: "/" + unquote($topbar-media-query) + "/";
+      width: $topbar-breakpoint;
+    }
+
+    /* Wrapped around .top-bar to contain to grid width */
+    .contain-to-grid {
+      width: 100%;
+      background: $topbar-bg;
+
+      .top-bar {
+        margin-bottom: $topbar-margin-bottom;
+      }
+    }
+
+    // Wrapped around .top-bar to make it stick to the top
+    .fixed {
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 99;
+      #{$default-float}: 0;
+
+      &.expanded:not(.top-bar) {
+        height: auto;
+        max-height: 100%;
+        overflow-y: auto;
+        width: 100%;
+
+        .title-area {
+          position: fixed;
+          width: 100%;
+          z-index: 99;
+        }
+
+        // Ensure you can scroll the menu on small screens
+        .top-bar-section {
+          margin-top: $topbar-height;
+          z-index: 98;
+        }
+      }
+    }
+
+    .top-bar {
+      background: $topbar-bg;
+      height: $topbar-height;
+      line-height: $topbar-height;
+      margin-bottom: $topbar-margin-bottom;
+      overflow: hidden;
+      position: relative;
+
+      // Topbar Global list Styles
+      ul {
+        list-style: none;
+        margin-bottom: 0;
+      }
+
+      .row {
+        max-width: none;
+      }
+
+      form,
+      input,
+      select {
+        margin-bottom: 0;
+      }
+
+      input,
+      select {
+        font-size: $topbar-button-font-size;
+        height: $topbar-input-height;
+        padding-bottom: px(.35rem);
+        padding-top: px(.35rem);
+      }
+
+      .button, button {
+        font-size: $topbar-button-font-size;
+        margin-bottom: 0;
+        padding-bottom: px(.35rem) + rem-calc(1);
+        padding-top: px(.35rem) + rem-calc(1);
+        // position: relative;
+        // top: -1px;
+
+        // Corrects a slight misalignment when put next to an input field
+        @media #{$small-only} {
+          position: relative;
+          top: -1px;
+        }
+      }
+
+      // Title Area
+      .title-area {
+        margin: 0;
+        position: relative;
+      }
+
+      .name {
+        font-size: $rem-base;
+        height: $topbar-height;
+        margin: 0;
+
+        h1, h2, h3, h4, p, span {
+          font-size: $topbar-title-font-size;
+          line-height: $topbar-height;
+          margin: 0;
+
+          a {
+            color: $topbar-link-color;
+            display: block;
+            font-weight: $topbar-title-weight;
+            padding: 0 $topbar-link-padding;
+            width: 75%;
+          }
+        }
+      }
+
+      // Menu toggle button on small devices
+      .toggle-topbar {
+        position: absolute;
+        #{$topbar-menu-icon-position}: 0;
+        top: 0;
+
+        a {
+          color: $topbar-link-color;
+          display: block;
+          font-size: $topbar-menu-link-font-size;
+          font-weight: $topbar-menu-link-weight;
+          height: $topbar-height;
+          line-height: $topbar-height;
+          padding: 0 $topbar-link-padding;
+          position: relative;
+          text-transform: $topbar-menu-link-transform;
+        }
+
+        // Adding the class "menu-icon" will add the 3-line icon people love and adore.
+        &.menu-icon {
+          margin-top: -16px;
+          top: 50%;
+
+          a {
+            @include hamburger(16px, false, 0, 1px, 6px, $topbar-menu-icon-color, "", false);
+
+            @if $text-direction == rtl {
+              text-indent: -58px;
+            }
+            color: $topbar-menu-link-color;
+            height: 34px;
+            line-height: 33px;
+            padding: 0 $topbar-link-padding+rem-calc(25) 0 $topbar-link-padding;
+            position: relative;
+          }
+        }
+      }
+
+      // Change things up when the top-bar is expanded
+      &.expanded {
+        background: transparent;
+        height: auto;
+
+        .title-area {
+          background: $topbar-bg;
+        }
+
+        .toggle-topbar {
+          a {
+            color: $topbar-menu-link-color-toggled;
+
+            span::after {
+              // Shh, don't tell, but box-shadows create the menu icon :)
+              // Change the color of the bars when the menu is expanded, using given thickness from hamburger() above
+              box-shadow: 0 0 0 1px $topbar-menu-icon-color-toggled,
+                          0 7px 0 1px $topbar-menu-icon-color-toggled,
+                          0 14px 0 1px $topbar-menu-icon-color-toggled;
+            }
+          }
+        }
+
+        // Fixes an issue with Desktop and Mobile Safari where deeply-nested menus don't appear
+        @media screen and (-webkit-min-device-pixel-ratio:0) {
+          .top-bar-section {
+            .has-dropdown.moved > .dropdown,
+            .dropdown {
+              clip: initial;
+            }
+
+            // This was needed as parent ul's had padding, and the clip: was allowing content to peak through
+            .has-dropdown:not(.moved) > ul {
+              padding: 0;
+            }
+          }
+        }
+      }
+    }
+
+    // Right and Left Navigation that stacked by default
+    .top-bar-section {
+      #{$default-float}: 0;
+      position: relative;
+      width: auto;
+      @include single-transition($default-float, $topbar-transition-speed);
+
+      ul {
+        display: block;
+        font-size: $rem-base;
+        height: auto;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+      }
+
+      .divider,
+      [role="separator"] {
+        border-top: $topbar-divider-border-top;
+        clear: both;
+        height: 1px;
+        width: 100%;
+      }
+
+      ul li {
+        background: $topbar-dropdown-bg;
+
+        > a {
+          color: $topbar-link-color;
+          display: block;
+          font-family: $topbar-link-font-family;
+          font-size: $topbar-link-font-size;
+          font-weight: $topbar-link-weight;
+          padding-#{$default-float}: $topbar-link-padding;
+          padding: 12px 0 12px $topbar-link-padding;
+          text-transform: $topbar-link-text-transform;
+          width: 100%;
+
+          &.button {
+            font-size: $topbar-link-font-size;
+            padding-#{$default-float}: $topbar-link-padding;
+            padding-#{$opposite-direction}: $topbar-link-padding;
+            @include button-style($bg:$primary-color);
+          }
+
+          &.button.secondary { @include button-style($bg:$secondary-color); }
+          &.button.success { @include button-style($bg:$success-color); }
+          &.button.alert { @include button-style($bg:$alert-color); }
+          &.button.warning { @include button-style($bg:$warning-color); }
+          &.button.info { @include button-style($bg:$info-color); }
+        }
+
+        > button {
+          font-size: $topbar-link-font-size;
+          padding-#{$default-float}: $topbar-link-padding;
+          padding-#{$opposite-direction}: $topbar-link-padding;
+          @include button-style($bg:$primary-color);
+
+          &.secondary { @include button-style($bg:$secondary-color); }
+          &.success { @include button-style($bg:$success-color); }
+          &.alert { @include button-style($bg:$alert-color); }
+          &.warning { @include button-style($bg:$warning-color); }
+          &.info { @include button-style($bg:$info-color); }
+        }
+
+        // Apply the hover link color when it has that class
+        &:hover:not(.has-form) > a {
+          background-color: $topbar-link-bg-color-hover;
+          color: $topbar-link-color-hover;
+
+          @if ($topbar-link-bg-hover) {
+            background: $topbar-link-bg-hover;
+          }
+        }
+
+        // Apply the active link color when it has that class
+        &.active > a {
+          background: $topbar-link-bg-active;
+          color: $topbar-link-color-active;
+
+          &:hover {
+            background: $topbar-link-bg-active-hover;
+            color: $topbar-link-color-active-hover;
+          }
+        }
+      }
+
+      // Add some extra padding for list items contains buttons
+      .has-form {
+        padding: $topbar-link-padding;
+      }
+
+      // Styling for list items that have a dropdown within them.
+      .has-dropdown {
+        position: relative;
+
+        > a {
+          &:after {
+            @if ($topbar-arrows) {
+              @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), $default-float);
+            }
+
+            margin-#{$opposite-direction}: $topbar-link-padding;
+            margin-top: -($topbar-dropdown-toggle-size / 2) - 2;
+            position: absolute;
+            top: 50%;
+            #{$opposite-direction}: 0;
+          }
+        }
+
+        &.moved {
+          position: static;
+
+          > .dropdown {
+            @include topbar-show-dropdown();
+            width: 100%;
+          }
+
+          > a:after {
+            display: none;
+          }
+        }
+      }
+
+      // Styling elements inside of dropdowns
+      .dropdown {
+        @include topbar-hide-dropdown();
+        padding: 0;
+        position: absolute;
+        top: 0;
+        z-index: 99;
+        #{$default-float}: 100%;
+
+        li {
+          height: auto;
+          width: 100%;
+
+          a {
+            font-weight: $topbar-dropdown-link-weight;
+            padding: 8px $topbar-link-padding;
+            &.parent-link {
+              font-weight: $topbar-link-weight;
+            }
+          }
+
+          &.title h5,
+          &.parent-link {
+            // Back Button
+            margin-bottom: 0;
+            margin-top: 0;
+            font-size: $topbar-back-link-size;
+            a {
+              color: $topbar-link-color;
+              // line-height: ($topbar-height / 2);
+              display: block;
+              &:hover { background:none; }
+            }
+          }
+
+          &.has-form {
+            padding: 8px $topbar-link-padding;
+          }
+
+          .button,
+          button {
+            top: auto;
+          }
+        }
+
+        label {
+          color: $topbar-dropdown-label-color;
+          font-size: $topbar-dropdown-label-font-size;
+          font-weight: $topbar-dropdown-label-font-weight;
+          margin-bottom: 0;
+          padding: 8px $topbar-link-padding 2px;
+          text-transform: $topbar-dropdown-label-text-transform;
+        }
+      }
+    }
+
+    .js-generated { display: block; }
+
+
+    // Top Bar styles intended for screen sizes above the breakpoint.
+    @media #{$topbar-media-query} {
+      .top-bar {
+        @include clearfix;
+        background: $topbar-bg;
+        overflow: visible;
+
+        .toggle-topbar { display: none; }
+
+        .title-area { float: $default-float; }
+        .name h1 a,
+        .name h2 a,
+        .name h3 a,
+        .name h4 a,
+        .name h5 a,
+        .name h6 a { width: auto; }
+
+        input,
+        select,
+        .button,
+        button {
+          font-size: rem-calc(14);
+          height: $topbar-input-height;
+          position: relative;
+          top: (($topbar-height - $topbar-input-height) / 2);
+        }
+
+        .has-form > .button,
+        .has-form > button {
+          font-size: rem-calc(14);
+          height: $topbar-input-height;
+          position: relative;
+          top: (($topbar-height - $topbar-input-height) / 2);
+        }
+
+        &.expanded {
+          background: $topbar-bg;
+        }
+      }
+
+      .contain-to-grid .top-bar {
+        margin: 0 auto;
+        margin-bottom: $topbar-margin-bottom;
+        max-width: $row-width;
+      }
+
+      .top-bar-section {
+        @include single-transition(none,0,0);
+        #{$default-float}: 0 !important;
+
+        ul {
+          display: inline;
+          height: auto !important;
+          width: auto;
+
+          li {
+            float: $default-float;
+            .js-generated { display: none; }
+          }
+        }
+
+        li {
+          &.hover {
+            > a:not(.button) {
+              background-color: $topbar-link-bg-color-hover;
+              @if ($topbar-link-bg-hover) {
+                background: $topbar-link-bg-hover;
+              }
+              color: $topbar-link-color-hover;
+            }
+          }
+
+          &:not(.has-form) {
+            a:not(.button) {
+              background: $topbar-link-bg;
+              line-height: $topbar-height;
+              padding: 0 $topbar-link-padding;
+              &:hover {
+                background-color: $topbar-link-bg-color-hover;
+                @if ($topbar-link-bg-hover) {
+                  background: $topbar-link-bg-hover;
+                }
+              }
+            }
+          }
+
+          &.active:not(.has-form) {
+            a:not(.button) {
+              background: $topbar-link-bg-active;
+              color: $topbar-link-color-active;
+              line-height: $topbar-height;
+              padding: 0 $topbar-link-padding;
+              &:hover {
+                background: $topbar-link-bg-active-hover;
+                color: $topbar-link-color-active-hover;
+              }
+            }
+          }
+        }
+
+        .has-dropdown {
+          @if $topbar-arrows {
+            > a {
+              padding-#{$opposite-direction}: $topbar-link-padding + $topbar-link-dropdown-padding !important;
+              &:after {
+                @include css-triangle($topbar-dropdown-toggle-size, rgba($topbar-dropdown-toggle-color, $topbar-dropdown-toggle-alpha), top);
+                margin-top: -($topbar-dropdown-toggle-size / 2);
+                top: ($topbar-height / 2);
+              }
+            }
+          }
+
+          &.moved { position: relative;
+            > .dropdown {
+              @include topbar-hide-dropdown();
+            }
+          }
+
+          &.hover, &.not-click:hover {
+            > .dropdown {
+              @include topbar-show-dropdown();
+            }
+          }
+
+          > a:focus + .dropdown {
+            @include topbar-show-dropdown();
+          }
+
+          .dropdown li.has-dropdown {
+            > a {
+              @if ($topbar-dropdown-arrows) {
+                &:after {
+                  border: none;
+                  content: "\00bb";
+                  top: rem-calc(3);
+
+                  #{$opposite-direction}: 5px;
+                }
+              }
+            }
+          }
+        }
+
+        .dropdown {
+          #{$default-float}: 0;
+          background: transparent;
+          min-width: 100%;
+          top: auto;
+
+          li {
+            a {
+              background: $topbar-dropdown-link-bg;
+              color: $topbar-dropdown-link-color;
+              line-height: $topbar-height;
+              padding: 12px $topbar-link-padding;
+              white-space: nowrap;
+            }
+
+            &:not(.has-form):not(.active) {
+              > a:not(.button) {
+                background: $topbar-dropdown-link-bg;
+                color: $topbar-dropdown-link-color;
+              }
+
+              &:hover > a:not(.button) {
+                background-color: $topbar-link-bg-color-hover;
+                color: $topbar-dropdown-link-color-hover;
+                @if ($topbar-dropdown-link-bg-hover) {
+                  background: $topbar-dropdown-link-bg-hover;
+                }
+              }
+            }
+
+            label {
+              background: $topbar-dropdown-label-bg;
+              white-space: nowrap;
+            }
+
+            // Second Level Dropdowns
+            .dropdown {
+              #{$default-float}: 100%;
+              top: 0;
+            }
+          }
+        }
+
+        > ul > .divider,
+        > ul > [role="separator"] {
+          border-#{$opposite-direction}: $topbar-divider-border-bottom;
+          border-bottom: none;
+          border-top: none;
+          clear: none;
+          height: $topbar-height;
+          width: 0;
+        }
+
+        .has-form {
+          background: $topbar-link-bg;
+          height: $topbar-height;
+          padding: 0 $topbar-link-padding;
+        }
+
+        // Position overrides for ul.right and ul.left
+        .#{$opposite-direction} {
+          li .dropdown {
+            #{$default-float}: auto;
+            #{$opposite-direction}: 0;
+
+            li .dropdown { #{$opposite-direction}: 100%; }
+          }
+        }
+        .#{$default-float} {
+          li .dropdown {
+            #{$opposite-direction}: auto;
+            #{$default-float}: 0;
+
+            li .dropdown { #{$default-float}: 100%; }
+          }
+        }
+      }
+
+      // Degrade gracefully when Javascript is disabled. Displays dropdown and changes
+      // background & text color on hover.
+      .no-js .top-bar-section {
+        ul li {
+          // Apply the hover link color when it has that class
+          &:hover > a {
+            background-color: $topbar-link-bg-color-hover;
+            @if ($topbar-link-bg-hover) {
+              background: $topbar-link-bg-hover;
+            }
+            color: $topbar-link-color-hover;
+          }
+
+          // Apply the active link color when it has that class
+          &:active > a {
+            background: $topbar-link-bg-active;
+            color: $topbar-link-color-active;
+          }
+        }
+
+        .has-dropdown {
+          &:hover {
+            > .dropdown {
+              @include topbar-show-dropdown();
+            }
+          }
+
+          > a:focus + .dropdown {
+            @include topbar-show-dropdown();
+          }
+        }
+      }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_type.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_type.scss
@@ -1,0 +1,467 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+$include-html-type-classes: $include-html-classes !default;
+
+// We use these to control header font styles
+$header-font-family: $body-font-family !default;
+$header-font-weight: $font-weight-normal !default;
+$header-font-style: normal !default;
+$header-font-color: $jet !default;
+$header-line-height: 1.4 !default;
+$header-top-margin: px(.2rem) !default;
+$header-bottom-margin: px(.5rem) !default;
+$header-text-rendering: optimizeLegibility !default;
+
+// We use these to control header font sizes
+$h1-font-size: rem-calc(44) !default;
+$h2-font-size: rem-calc(37) !default;
+$h3-font-size: rem-calc(27) !default;
+$h4-font-size: rem-calc(23) !default;
+$h5-font-size: rem-calc(18) !default;
+$h6-font-size: px(1rem) !default;
+
+// We use these to control header size reduction on small screens
+$h1-font-reduction: rem-calc(10) !default;
+$h2-font-reduction: rem-calc(10) !default;
+$h3-font-reduction: rem-calc(5) !default;
+$h4-font-reduction: rem-calc(5) !default;
+$h5-font-reduction: 0 !default;
+$h6-font-reduction: 0 !default;
+
+// These control how subheaders are styled.
+$subheader-line-height: 1.4 !default;
+$subheader-font-color: scale-color($header-font-color, $lightness: 35%) !default;
+$subheader-font-weight: $font-weight-normal !default;
+$subheader-top-margin: px(.2rem) !default;
+$subheader-bottom-margin: px(.5rem) !default;
+
+// A general <small> styling
+$small-font-size: 60% !default;
+$small-font-color: scale-color($header-font-color, $lightness: 35%) !default;
+
+// We use these to style paragraphs
+$paragraph-font-family: inherit !default;
+$paragraph-font-weight: $font-weight-normal !default;
+$paragraph-font-size: px(1rem) !default;
+$paragraph-line-height: 1.6 !default;
+$paragraph-margin-bottom: rem-calc(20) !default;
+$paragraph-aside-font-size: rem-calc(14) !default;
+$paragraph-aside-line-height: 1.35 !default;
+$paragraph-aside-font-style: italic !default;
+$paragraph-text-rendering: optimizeLegibility !default;
+
+// We use these to style <code> tags
+$code-color: $oil !default;
+$code-font-family: $font-family-monospace !default;
+$code-font-weight: $font-weight-normal !default;
+$code-background-color: scale-color($secondary-color, $lightness: 70%) !default;
+$code-border-size: 1px !default;
+$code-border-style: solid !default;
+$code-border-color: scale-color($code-background-color, $lightness: -10%) !default;
+$code-padding: rem-calc(2) rem-calc(5) rem-calc(1) !default;
+
+// We use these to style anchors
+$anchor-text-decoration: none !default;
+$anchor-text-decoration-hover: none !default;
+$anchor-font-color: $primary-color !default;
+$anchor-font-color-hover: scale-color($anchor-font-color, $lightness: -14%) !default;
+
+// We use these to style the <hr> element
+$hr-border-width: 1px !default;
+$hr-border-style: solid !default;
+$hr-border-color: $gainsboro !default;
+$hr-margin: rem-calc(20) !default;
+
+// We use these to style lists
+$list-font-family: $paragraph-font-family !default;
+$list-font-size: $paragraph-font-size !default;
+$list-line-height: $paragraph-line-height !default;
+$list-margin-bottom: $paragraph-margin-bottom !default;
+$list-style-position: outside !default;
+$list-side-margin: px(1.1rem) !default;
+$list-ordered-side-margin: px(1.4rem) !default;
+$list-side-margin-no-bullet: 0 !default;
+$list-nested-margin: rem-calc(20) !default;
+$definition-list-header-weight: $font-weight-bold !default;
+$definition-list-header-margin-bottom: px(.3rem) !default;
+$definition-list-margin-bottom: rem-calc(12) !default;
+
+// We use these to style blockquotes
+$blockquote-font-color: scale-color($header-font-color, $lightness: 35%) !default;
+$blockquote-padding: rem-calc(9 20 0 19) !default;
+$blockquote-border: 1px solid $gainsboro !default;
+$blockquote-cite-font-size: rem-calc(13) !default;
+$blockquote-cite-font-color: scale-color($header-font-color, $lightness: 23%) !default;
+$blockquote-cite-link-color: $blockquote-cite-font-color !default;
+
+// Acronym styles
+$acronym-underline: 1px dotted $gainsboro !default;
+
+// We use these to control padding and margin
+$microformat-padding: rem-calc(10 12) !default;
+$microformat-margin: rem-calc(0 0 20 0) !default;
+
+// We use these to control the border styles
+$microformat-border-width: 1px !default;
+$microformat-border-style: solid !default;
+$microformat-border-color: $gainsboro !default;
+
+// We use these to control full name font styles
+$microformat-fullname-font-weight: $font-weight-bold !default;
+$microformat-fullname-font-size: rem-calc(15) !default;
+
+// We use this to control the summary font styles
+$microformat-summary-font-weight: $font-weight-bold !default;
+
+// We use this to control abbr padding
+$microformat-abbr-padding: rem-calc(0 1) !default;
+
+// We use this to control abbr font styles
+$microformat-abbr-font-weight: $font-weight-bold !default;
+$microformat-abbr-font-decoration: none !default;
+
+// Text alignment class names
+$align-class-names:
+  small-only,
+  small,
+  medium-only,
+  medium,
+  large-only,
+  large,
+  xlarge-only,
+  xlarge,
+  xxlarge-only,
+  xxlarge;
+
+// Text alignment breakpoints
+$align-class-breakpoints:
+  $small-only,
+  $small-up,
+  $medium-only,
+  $medium-up,
+  $large-only,
+  $large-up,
+  $xlarge-only,
+  $xlarge-up,
+  $xxlarge-only,
+  $xxlarge-up;
+
+// Generates text align and justify classes
+@mixin align-classes{
+  .text-left    { text-align: left !important; }
+  .text-right   { text-align: right !important; }
+  .text-center  { text-align: center !important; }
+  .text-justify { text-align: justify !important; }
+
+  @for $i from 1 through length($align-class-names) {
+    @media #{(nth($align-class-breakpoints, $i))} {
+      .#{(nth($align-class-names, $i))}-text-left { text-align: left !important; }
+      .#{(nth($align-class-names, $i))}-text-right   { text-align: right !important; }
+      .#{(nth($align-class-names, $i))}-text-center  { text-align: center !important; }
+      .#{(nth($align-class-names, $i))}-text-justify { text-align: justify !important; }
+    }
+  }
+}
+
+//
+// Typography Placeholders
+//
+
+// These will throw a deprecation warning if used within a media query.
+@mixin lead {
+  font-size: $paragraph-font-size + rem-calc(3.5);
+  line-height: 1.6;
+}
+
+@mixin subheader {
+  line-height: $subheader-line-height;
+  color: $subheader-font-color;
+  font-weight: $subheader-font-weight;
+  margin-top: $subheader-top-margin;
+  margin-bottom: $subheader-bottom-margin;
+}
+@include exports("type") {
+  @if $include-html-type-classes {
+    // Responsive Text alignment
+    @include align-classes;
+
+    /* Typography resets */
+    div,
+    dl,
+    dt,
+    dd,
+    ul,
+    ol,
+    li,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    pre,
+    form,
+    p,
+    blockquote,
+    th,
+    td {
+      margin:0;
+      padding:0;
+    }
+
+    /* Default Link Styles */
+    a {
+      color: $anchor-font-color;
+      line-height: inherit;
+      text-decoration: $anchor-text-decoration;
+
+      &:hover,
+      &:focus {
+        color: $anchor-font-color-hover;
+        @if $anchor-text-decoration-hover != $anchor-text-decoration {
+        	text-decoration: $anchor-text-decoration-hover;
+        }
+      }
+
+      img { border:none; }
+    }
+
+    /* Default paragraph styles */
+    p {
+      font-family: $paragraph-font-family;
+      font-size: $paragraph-font-size;
+      font-weight: $paragraph-font-weight;
+      line-height: $paragraph-line-height;
+      margin-bottom: $paragraph-margin-bottom;
+      text-rendering: $paragraph-text-rendering;
+
+      &.lead { @include lead; }
+
+      & aside {
+        font-size: $paragraph-aside-font-size;
+        font-style: $paragraph-aside-font-style;
+        line-height: $paragraph-aside-line-height;
+      }
+    }
+
+    /* Default header styles */
+    h1, h2, h3, h4, h5, h6 {
+      color: $header-font-color;
+      font-family: $header-font-family;
+      font-style: $header-font-style;
+      font-weight: $header-font-weight;
+      line-height: $header-line-height;
+      margin-bottom: $header-bottom-margin;
+      margin-top: $header-top-margin;
+      text-rendering: $header-text-rendering;
+
+      small {
+        color: $small-font-color;
+        font-size: $small-font-size;
+        line-height: 0;
+      }
+    }
+
+    h1 { font-size: $h1-font-size - $h1-font-reduction; }
+    h2 { font-size: $h2-font-size - $h2-font-reduction; }
+    h3 { font-size: $h3-font-size - $h3-font-reduction; }
+    h4 { font-size: $h4-font-size - $h4-font-reduction; }
+    h5 { font-size: $h5-font-size - $h5-font-reduction; }
+    h6 { font-size: $h6-font-size - $h6-font-reduction; }
+
+    .subheader { @include subheader; }
+
+    hr {
+      border: $hr-border-style $hr-border-color;
+      border-width: $hr-border-width 0 0;
+      clear: both;
+      height: 0;
+      margin: $hr-margin 0 ($hr-margin - rem-calc($hr-border-width));
+    }
+
+    /* Helpful Typography Defaults */
+    em,
+    i {
+      font-style: italic;
+      line-height: inherit;
+    }
+
+    strong,
+    b {
+      font-weight: $font-weight-bold;
+      line-height: inherit;
+    }
+
+    small {
+      font-size: $small-font-size;
+      line-height: inherit;
+    }
+
+    code {
+      background-color: $code-background-color;
+      border-color: $code-border-color;
+      border-style: $code-border-style;
+      border-width: $code-border-size;
+      color: $code-color;
+      font-family: $code-font-family;
+      font-weight: $code-font-weight;
+      padding: $code-padding;
+    }
+
+    /* Lists */
+    ul,
+    ol,
+    dl {
+      font-family: $list-font-family;
+      font-size: $list-font-size;
+      line-height: $list-line-height;
+      list-style-position: $list-style-position;
+      margin-bottom: $list-margin-bottom;
+    }
+
+    ul {
+      margin-#{$default-float}: $list-side-margin;
+    }
+
+    /* Unordered Lists */
+    ul {
+      li {
+        ul,
+        ol {
+          margin-#{$default-float}: $list-nested-margin;
+          margin-bottom: 0;
+        }
+      }
+      &.square,
+      &.circle,
+      &.disc {
+        li ul { list-style: inherit; }
+      }
+
+      &.square { list-style-type: square; margin-#{$default-float}: $list-side-margin;}
+      &.circle { list-style-type: circle; margin-#{$default-float}: $list-side-margin;}
+      &.disc { list-style-type: disc; margin-#{$default-float}: $list-side-margin;}
+    }
+
+    /* Ordered Lists */
+    ol {
+      margin-#{$default-float}: $list-ordered-side-margin;
+      li {
+        ul,
+        ol {
+          margin-#{$default-float}: $list-nested-margin;
+          margin-bottom: 0;
+        }
+      }
+    }
+
+    // Lists without bullets
+    .no-bullet {
+      list-style-type: none;
+      margin-#{$default-float}: $list-side-margin-no-bullet;
+
+      li {
+        ul,
+        ol {
+          margin-#{$default-float}: $list-nested-margin;
+          margin-bottom: 0;
+          list-style: none;
+        }
+      }
+    }
+
+    /* Definition Lists */
+    dl {
+      dt {
+        margin-bottom: $definition-list-header-margin-bottom;
+        font-weight: $definition-list-header-weight;
+      }
+      dd { margin-bottom: $definition-list-margin-bottom; }
+    }
+
+    /* Abbreviations */
+    abbr,
+    acronym {
+      text-transform: uppercase;
+      font-size: 90%;
+      color: $body-font-color;
+      cursor: $cursor-help-value;
+    }
+    abbr {
+      text-transform: none;
+      &[title] {
+        border-bottom: $acronym-underline;
+      }
+    }
+
+    /* Blockquotes */
+    blockquote {
+      margin: 0 0 $paragraph-margin-bottom;
+      padding: $blockquote-padding;
+      border-#{$default-float}: $blockquote-border;
+
+      cite {
+        display: block;
+        font-size: $blockquote-cite-font-size;
+        color: $blockquote-cite-font-color;
+        &:before {
+          content: "\2014 \0020";
+        }
+
+        a,
+        a:visited {
+          color: $blockquote-cite-link-color;
+        }
+      }
+    }
+    blockquote,
+    blockquote p {
+      line-height: $paragraph-line-height;
+      color: $blockquote-font-color;
+    }
+
+    /* Microformats */
+    .vcard {
+      display: inline-block;
+      margin: $microformat-margin;
+      border: $microformat-border-width $microformat-border-style $microformat-border-color;
+      padding: $microformat-padding;
+
+      li {
+        margin: 0;
+        display: block;
+      }
+      .fn {
+        font-weight: $microformat-fullname-font-weight;
+        font-size: $microformat-fullname-font-size;
+      }
+    }
+
+    .vevent {
+      .summary { font-weight: $microformat-summary-font-weight; }
+
+      abbr {
+        cursor: $cursor-default-value;
+        text-decoration: $microformat-abbr-font-decoration;
+        font-weight: $microformat-abbr-font-weight;
+        border: none;
+        padding: $microformat-abbr-padding;
+      }
+    }
+
+
+    @media #{$medium-up} {
+      h1, h2, h3, h4, h5, h6 { line-height: $header-line-height; }
+      h1 { font-size: $h1-font-size; }
+      h2 { font-size: $h2-font-size; }
+      h3 { font-size: $h3-font-size; }
+      h4 { font-size: $h4-font-size; }
+      h5 { font-size: $h5-font-size; }
+      h6 { font-size: $h6-font-size; }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/foundation/components/_visibility.scss
+++ b/situational/assets/print/foundation-print/scss/foundation/components/_visibility.scss
@@ -1,0 +1,492 @@
+// Foundation by ZURB
+// foundation.zurb.com
+// Licensed under MIT Open Source
+
+@import 'global';
+
+//
+// Foundation Visibility Classes
+//
+$include-html-visibility-classes: $include-html-classes !default;
+$include-accessibility-classes: true !default;
+$include-table-visibility-classes: true !default;
+$include-legacy-visibility-classes: true !default;
+
+//
+// Media Class Names
+//
+// Visibility Breakpoints
+$visibility-breakpoint-sizes:
+  small,
+  medium,
+  large,
+  xlarge,
+  xxlarge;
+
+$visibility-breakpoint-queries:
+  unquote($small-up),
+  unquote($medium-up),
+  unquote($large-up),
+  unquote($xlarge-up),
+  unquote($xxlarge-up);
+
+@mixin visibility-loop {
+  @each $current-visibility-breakpoint in $visibility-breakpoint-sizes {
+    $visibility-inherit-list: ();
+    $visibility-none-list: ();
+
+    $visibility-visible-list: ();
+    $visibility-hidden-list: ();
+
+    $visibility-table-list: ();
+    $visibility-table-header-group-list: ();
+    $visibility-table-row-group-list: ();
+    $visibility-table-row-list: ();
+    $visibility-table-cell-list: ();
+
+    @each $visibility-comparison-breakpoint in $visibility-breakpoint-sizes {
+      @if index($visibility-breakpoint-sizes, $visibility-comparison-breakpoint) < index($visibility-breakpoint-sizes, $current-visibility-breakpoint) {
+        // Smaller than current breakpoint
+
+        $visibility-inherit-list: append($visibility-inherit-list, unquote(
+          '.hide-for-#{$visibility-comparison-breakpoint}-only, .show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-none-list: append($visibility-none-list, unquote(
+          '.show-for-#{$visibility-comparison-breakpoint}-only, .hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-visible-list: append($visibility-visible-list, unquote(
+          '.hidden-for-#{$visibility-comparison-breakpoint}-only, .visible-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-hidden-list: append($visibility-hidden-list, unquote(
+          '.visible-for-#{$visibility-comparison-breakpoint}-only, .hidden-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-list: append($visibility-table-list, unquote(
+          'table.hide-for-#{$visibility-comparison-breakpoint}-only, table.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-header-group-list: append($visibility-table-header-group-list, unquote(
+          'thead.hide-for-#{$visibility-comparison-breakpoint}-only, thead.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-row-group-list: append($visibility-table-row-group-list, unquote(
+          'tbody.hide-for-#{$visibility-comparison-breakpoint}-only, tbody.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-row-list: append($visibility-table-row-list, unquote(
+          'tr.hide-for-#{$visibility-comparison-breakpoint}-only, tr.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-cell-list: append($visibility-table-cell-list, unquote(
+          'th.hide-for-#{$visibility-comparison-breakpoint}-only, td.hide-for-#{$visibility-comparison-breakpoint}-only, th.show-for-#{$visibility-comparison-breakpoint}-up, td.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+
+        // Foundation 4 compatibility:
+        // Include .show/hide-for-[size] and .show/hide-for-[size]-down classes
+        // for small, medium, and large breakpoints only
+        @if $include-legacy-visibility-classes and index((small, medium, large), $visibility-comparison-breakpoint) != false {
+          $visibility-inherit-list: append($visibility-inherit-list, unquote(
+            '.hide-for-#{$visibility-comparison-breakpoint}, .hide-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-none-list: append($visibility-none-list, unquote(
+            '.show-for-#{$visibility-comparison-breakpoint}, .show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-visible-list: append($visibility-visible-list, unquote(
+            '.hidden-for-#{$visibility-comparison-breakpoint}, .hidden-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-hidden-list: append($visibility-hidden-list, unquote(
+            '.visible-for-#{$visibility-comparison-breakpoint}, .visible-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-list: append($visibility-table-list, unquote(
+            'table.hide-for-#{$visibility-comparison-breakpoint}, table.hide-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-header-group-list: append($visibility-table-header-group-list, unquote(
+            'thead.hide-for-#{$visibility-comparison-breakpoint}, thead.hide-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-row-group-list: append($visibility-table-row-group-list, unquote(
+            'tbody.hide-for-#{$visibility-comparison-breakpoint}, tbody.hide-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-row-list: append($visibility-table-row-list, unquote(
+            'tr.hide-for-#{$visibility-comparison-breakpoint}, tr.hide-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-cell-list: append($visibility-table-cell-list, unquote(
+            'th.hide-for-#{$visibility-comparison-breakpoint}, td.hide-for-#{$visibility-comparison-breakpoint}, th.hide-for-#{$visibility-comparison-breakpoint}-down, td.hide-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+        }
+
+      } @else if index($visibility-breakpoint-sizes, $visibility-comparison-breakpoint) > index($visibility-breakpoint-sizes, $current-visibility-breakpoint) {
+        // Larger than current breakpoint
+
+        $visibility-inherit-list: append($visibility-inherit-list, unquote(
+          '.hide-for-#{$visibility-comparison-breakpoint}-only, .hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-none-list: append($visibility-none-list, unquote(
+          '.show-for-#{$visibility-comparison-breakpoint}-only, .show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-visible-list: append($visibility-visible-list, unquote(
+          '.hidden-for-#{$visibility-comparison-breakpoint}-only, .hidden-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-hidden-list: append($visibility-hidden-list, unquote(
+          '.visible-for-#{$visibility-comparison-breakpoint}-only, .visible-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-list: append($visibility-table-list, unquote(
+          'table.hide-for-#{$visibility-comparison-breakpoint}-only, table.hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-header-group-list: append($visibility-table-header-group-list, unquote(
+          'thead.hide-for-#{$visibility-comparison-breakpoint}-only, thead.hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-row-group-list: append($visibility-table-row-group-list, unquote(
+          'tbody.hide-for-#{$visibility-comparison-breakpoint}-only, tbody.hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-row-list: append($visibility-table-row-list, unquote(
+          'tr.hide-for-#{$visibility-comparison-breakpoint}-only, tr.hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-cell-list: append($visibility-table-cell-list, unquote(
+          'th.hide-for-#{$visibility-comparison-breakpoint}-only, td.hide-for-#{$visibility-comparison-breakpoint}-only, th.hide-for-#{$visibility-comparison-breakpoint}-up, td.hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+
+        // Foundation 4 compatibility:
+        // Include .show/hide-for-[size] and .show/hide-for-[size]-down classes
+        // for small, medium, and large breakpoints only
+        @if $include-legacy-visibility-classes and index((small, medium, large), $visibility-comparison-breakpoint) != false {
+          $visibility-inherit-list: append($visibility-inherit-list, unquote(
+            '.hide-for-#{$visibility-comparison-breakpoint}, .show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-none-list: append($visibility-none-list, unquote(
+            '.show-for-#{$visibility-comparison-breakpoint}, .hide-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-visible-list: append($visibility-visible-list, unquote(
+            '.hidden-for-#{$visibility-comparison-breakpoint}, .visible-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-hidden-list: append($visibility-hidden-list, unquote(
+            '.visible-for-#{$visibility-comparison-breakpoint}, .hidden-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-list: append($visibility-table-list, unquote(
+            'table.hide-for-#{$visibility-comparison-breakpoint}, table.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-header-group-list: append($visibility-table-header-group-list, unquote(
+            'thead.hide-for-#{$visibility-comparison-breakpoint}, thead.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-row-group-list: append($visibility-table-row-group-list, unquote(
+            'tbody.hide-for-#{$visibility-comparison-breakpoint}, tbody.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-row-list: append($visibility-table-row-list, unquote(
+            'tr.hide-for-#{$visibility-comparison-breakpoint}, tr.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-cell-list: append($visibility-table-cell-list, unquote(
+            'th.hide-for-#{$visibility-comparison-breakpoint}, td.hide-for-#{$visibility-comparison-breakpoint}, th.show-for-#{$visibility-comparison-breakpoint}-down, td.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+        }
+
+      } @else {
+        // Current breakpoint
+
+        $visibility-inherit-list: append($visibility-inherit-list, unquote(
+          '.show-for-#{$visibility-comparison-breakpoint}-only, .show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-none-list: append($visibility-none-list, unquote(
+          '.hide-for-#{$visibility-comparison-breakpoint}-only, .hide-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-visible-list: append($visibility-visible-list, unquote(
+          '.visible-for-#{$visibility-comparison-breakpoint}-only, .visible-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-hidden-list: append($visibility-hidden-list, unquote(
+          '.hidden-for-#{$visibility-comparison-breakpoint}-only, .hidden-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-list: append($visibility-table-list, unquote(
+          'table.show-for-#{$visibility-comparison-breakpoint}-only, table.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-header-group-list: append($visibility-table-header-group-list, unquote(
+          'thead.show-for-#{$visibility-comparison-breakpoint}-only, thead.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-row-group-list: append($visibility-table-row-group-list, unquote(
+          'tbody.show-for-#{$visibility-comparison-breakpoint}-only, tbody.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-row-list: append($visibility-table-row-list, unquote(
+          'tr.show-for-#{$visibility-comparison-breakpoint}-only, tr.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+        $visibility-table-cell-list: append($visibility-table-cell-list, unquote(
+          'th.show-for-#{$visibility-comparison-breakpoint}-only, td.show-for-#{$visibility-comparison-breakpoint}-only, th.show-for-#{$visibility-comparison-breakpoint}-up, td.show-for-#{$visibility-comparison-breakpoint}-up'
+        ), comma);
+
+        // Foundation 4 compatibility:
+        // Include .show/hide-for-[size] and .show/hide-for-[size]-down classes
+        // for small, medium, and large breakpoints only
+        @if $include-legacy-visibility-classes and index((small, medium, large), $visibility-comparison-breakpoint) != false {
+          $visibility-inherit-list: append($visibility-inherit-list, unquote(
+            '.show-for-#{$visibility-comparison-breakpoint}, .show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-none-list: append($visibility-none-list, unquote(
+            '.hide-for-#{$visibility-comparison-breakpoint}, .hide-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-visible-list: append($visibility-visible-list, unquote(
+            '.visible-for-#{$visibility-comparison-breakpoint}, .visible-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-hidden-list: append($visibility-hidden-list, unquote(
+            '.hidden-for-#{$visibility-comparison-breakpoint}, .hidden-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-list: append($visibility-table-list, unquote(
+            'table.show-for-#{$visibility-comparison-breakpoint}, table.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-header-group-list: append($visibility-table-header-group-list, unquote(
+            'thead.show-for-#{$visibility-comparison-breakpoint}, thead.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-row-group-list: append($visibility-table-row-group-list, unquote(
+            'tbody.show-for-#{$visibility-comparison-breakpoint}, tbody.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-row-list: append($visibility-table-row-list, unquote(
+            'tr.show-for-#{$visibility-comparison-breakpoint}, tr.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+          $visibility-table-cell-list: append($visibility-table-cell-list, unquote(
+            'th.show-for-#{$visibility-comparison-breakpoint}, td.show-for-#{$visibility-comparison-breakpoint}, th.show-for-#{$visibility-comparison-breakpoint}-down, td.show-for-#{$visibility-comparison-breakpoint}-down'
+          ), comma);
+        }
+      }
+    }
+
+    /* #{$current-visibility-breakpoint} displays */
+    @media #{nth($visibility-breakpoint-queries, index($visibility-breakpoint-sizes, $current-visibility-breakpoint))} {
+      #{$visibility-inherit-list} {
+        display: inherit !important;
+      }
+      #{$visibility-none-list} {
+        display: none !important;
+      }
+      @if $include-accessibility-classes != false {
+        #{$visibility-visible-list} {
+          @include element-invisible-off;
+        }
+        #{$visibility-hidden-list} {
+          @include element-invisible;
+        }
+      }
+      @if $include-table-visibility-classes != false {
+        #{$visibility-table-list} {
+          display: table !important;
+        }
+        #{$visibility-table-header-group-list} {
+          display: table-header-group !important;
+        }
+        #{$visibility-table-row-group-list} {
+          display: table-row-group !important;
+        }
+        #{$visibility-table-row-list} {
+          display: table-row;
+        }
+        #{$visibility-table-cell-list} {
+          display: table-cell !important;
+        }
+      }
+    }
+  }
+}
+
+@include exports("visibility"){
+  @if $include-html-visibility-classes != false {
+
+  @include visibility-loop;
+
+  /* Orientation targeting */
+  .show-for-landscape,
+  .hide-for-portrait { display: inherit !important; }
+  .hide-for-landscape,
+  .show-for-portrait { display: none !important; }
+
+  /* Specific visibility for tables */
+  table {
+    &.hide-for-landscape,
+    &.show-for-portrait { display: table !important; }
+  }
+  thead {
+    &.hide-for-landscape,
+    &.show-for-portrait { display: table-header-group !important; }
+  }
+  tbody {
+    &.hide-for-landscape,
+    &.show-for-portrait { display: table-row-group !important; }
+  }
+  tr {
+    &.hide-for-landscape,
+    &.show-for-portrait { display: table-row !important; }
+  }
+  td,
+  th {
+    &.hide-for-landscape,
+    &.show-for-portrait { display: table-cell !important; }
+  }
+
+  @media #{$landscape} {
+    .show-for-landscape,
+    .hide-for-portrait { display: inherit !important; }
+    .hide-for-landscape,
+    .show-for-portrait { display: none !important; }
+
+    /* Specific visibility for tables */
+    table {
+      &.show-for-landscape,
+      &.hide-for-portrait { display: table !important; }
+    }
+    thead {
+      &.show-for-landscape,
+      &.hide-for-portrait { display: table-header-group !important; }
+    }
+    tbody {
+      &.show-for-landscape,
+      &.hide-for-portrait { display: table-row-group !important; }
+    }
+    tr {
+      &.show-for-landscape,
+      &.hide-for-portrait { display: table-row !important; }
+    }
+    td,
+    th {
+      &.show-for-landscape,
+      &.hide-for-portrait { display: table-cell !important; }
+    }
+  }
+
+  @media #{$portrait} {
+    .show-for-portrait,
+    .hide-for-landscape { display: inherit !important; }
+    .hide-for-portrait,
+    .show-for-landscape { display: none !important; }
+
+    /* Specific visibility for tables */
+    table {
+      &.show-for-portrait,
+      &.hide-for-landscape { display: table !important; }
+    }
+    thead {
+      &.show-for-portrait,
+      &.hide-for-landscape { display: table-header-group !important; }
+    }
+    tbody {
+      &.show-for-portrait,
+      &.hide-for-landscape { display: table-row-group !important; }
+    }
+    tr {
+      &.show-for-portrait,
+      &.hide-for-landscape { display: table-row !important; }
+    }
+    td,
+    th {
+      &.show-for-portrait,
+      &.hide-for-landscape { display: table-cell !important; }
+    }
+  }
+
+  /* Touch-enabled device targeting */
+  .show-for-touch { display: none !important; }
+  .hide-for-touch { display: inherit !important; }
+  .touch .show-for-touch { display: inherit !important; }
+  .touch .hide-for-touch { display: none !important; }
+
+  /* Specific visibility for tables */
+  table.hide-for-touch { display: table !important; }
+  .touch table.show-for-touch { display: table !important; }
+  thead.hide-for-touch { display: table-header-group !important; }
+  .touch thead.show-for-touch { display: table-header-group !important; }
+  tbody.hide-for-touch { display: table-row-group !important; }
+  .touch tbody.show-for-touch { display: table-row-group !important; }
+  tr.hide-for-touch { display: table-row !important; }
+  .touch tr.show-for-touch { display: table-row !important; }
+  td.hide-for-touch { display: table-cell !important; }
+  .touch td.show-for-touch { display: table-cell !important; }
+  th.hide-for-touch { display: table-cell !important; }
+  .touch th.show-for-touch { display: table-cell !important; }
+
+  /* Screen reader-specific classes */
+  .show-for-sr {
+    @include element-invisible;
+  }
+  .show-on-focus {
+    @include element-invisible;
+
+    &:focus,
+    &:active {
+      @include element-invisible-off;
+    }
+  }
+
+  // Only include these styles if you want them.
+    @if $include-print-styles {
+      /*
+       * Print styles.
+       *
+       * Inlined to avoid required HTTP connection: www.phpied.com/delay-loading-your-print-css/
+       * Credit to Paul Irish and HTML5 Boilerplate (html5boilerplate.com)
+      */
+      .print-only { display: none !important; }
+      @media print {
+        * {
+          background: transparent !important;
+          box-shadow: none !important;
+          color: $black !important; /* Black prints faster: h5bp.com/s */
+          text-shadow: none !important;
+        }
+        .show-for-print { display: block; }
+        .hide-for-print { display: none; }
+
+        table.show-for-print { display: table !important; }
+        thead.show-for-print { display: table-header-group !important; }
+        tbody.show-for-print { display: table-row-group !important; }
+        tr.show-for-print { display: table-row !important; }
+        td.show-for-print { display: table-cell !important; }
+        th.show-for-print { display: table-cell !important; }
+
+        a,
+        a:visited { text-decoration: underline;}
+        a[href]:after { content: " (" attr(href) ")"; }
+
+        abbr[title]:after { content: " (" attr(title) ")"; }
+
+        // Don't show links for images, or javascript/internal links
+        .ir a:after,
+        a[href^="javascript:"]:after,
+        a[href^="#"]:after { content: ""; }
+
+        pre,
+        blockquote {
+          border: 1px solid $aluminum;
+          page-break-inside: avoid;
+        }
+
+        thead { display: table-header-group; /* h5bp.com/t */ }
+
+        tr,
+        img { page-break-inside: avoid; }
+
+        img { max-width: 100% !important; }
+
+        @page { margin: .5cm; }
+
+        p,
+        h2,
+        h3 {
+          orphans: 3;
+          widows: 3;
+        }
+
+        h2,
+        h3 { page-break-after: avoid; }
+
+        .hide-on-print { display: none !important; }
+        .print-only { display: block !important; }
+        .hide-for-print { display: none !important; }
+        .show-for-print { display: inherit !important; }
+      }
+    }
+
+  /* Print visibility */
+    @media print {
+      .show-for-print { display: block; }
+      .hide-for-print { display: none; }
+
+      table.show-for-print { display: table !important; }
+      thead.show-for-print { display: table-header-group !important; }
+      tbody.show-for-print { display: table-row-group !important; }
+      tr.show-for-print { display: table-row !important; }
+      td.show-for-print { display: table-cell !important; }
+      th.show-for-print { display: table-cell !important; }
+    }
+
+    @media not print{
+      .show-for-print { display: none !important; }
+    }
+  }
+}

--- a/situational/assets/print/foundation-print/scss/normalize.scss
+++ b/situational/assets/print/foundation-print/scss/normalize.scss
@@ -1,0 +1,424 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  box-sizing: content-box; /* 2 */
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}


### PR DESCRIPTION
PrinceXML doesn't support rem, so this duplicates the whole of Foundation and hacks in pixels everywhere. (This is a bit of a brute-force solution)

This PR also introduces a new layout for the sectors report (that matches the summary), which was used to figure out whether the new print styles actually work...

It also introduces a "print-xxx" grid, which should be used for all grids in print-specific html
