### PR TITLE
Visualise progress through sectors tool

### DIFF
--- a/situational/apps/sectors/templates/sectors/_progress.html
+++ b/situational/apps/sectors/templates/sectors/_progress.html
@@ -1,0 +1,3 @@
+<div class="sector-progress">
+  Step {{ step_number }} of 3
+</div>

--- a/situational/apps/sectors/templates/sectors/job_descriptions.html
+++ b/situational/apps/sectors/templates/sectors/job_descriptions.html
@@ -20,6 +20,7 @@
 <article class="sectors">
   <div class="row">
     <div class="columns">
+      {% include 'sectors/_progress.html' with step_number=2 %}
       <h1>Jobs you'd like to know more about</h1>
       <p><a href="{% url 'sectors:wizard_step' step='sector_form' %}" class="button">Refine search</a></p>
 

--- a/situational/apps/sectors/templates/sectors/report_pending.html
+++ b/situational/apps/sectors/templates/sectors/report_pending.html
@@ -8,7 +8,8 @@
 
 {% block content %}
 <div class="row">
-  <div class="columns large-11 small-9">
+  <div class="columns">
+    {% include 'sectors/_progress.html' with step_number=3 %}
     <h1>Please wait while we generate your report...</h1>
     <ul>
       <li>{% include "sectors/_result_field_pending.html" with field="soc_code_data" message="Generating SOC code report..." %}</li>

--- a/situational/apps/sectors/templates/sectors/sector_form.html
+++ b/situational/apps/sectors/templates/sectors/sector_form.html
@@ -4,6 +4,7 @@
 {% block content %}
   <div class="row">
     <div class="columns large-8 large-centered">
+      {% include 'sectors/_progress.html' with step_number=1 %}
       <h1>About you</h1>
       <form method=post id="sector_form" autocomplete="OFF">
         {% csrf_token %}

--- a/situational/assets/css/styles.scss
+++ b/situational/assets/css/styles.scss
@@ -85,3 +85,10 @@
     }
   }
 }
+
+
+.sector-progress {
+  padding-top: 0.5em;
+  font-size: 0.8em;
+  color: $jumbo;
+}


### PR DESCRIPTION
An attempt at making it obvious that "select jobs" is not the end of the sectors tool, following the [service manual's recommendation of "Step X of X"](https://www.gov.uk/service-manual/user-centred-design/resources/patterns/progress-indicators).

<img width="665" alt="screen shot 2015-09-23 at 17 14 26" src="https://cloud.githubusercontent.com/assets/418277/10050924/b49fe73c-6216-11e5-81d3-6732be637ca6.png">

<img width="862" alt="screen shot 2015-09-23 at 17 14 53" src="https://cloud.githubusercontent.com/assets/418277/10050929/bd23750e-6216-11e5-889c-8008964b9122.png">

<img width="850" alt="screen shot 2015-09-23 at 17 15 12" src="https://cloud.githubusercontent.com/assets/418277/10050937/c74af9a8-6216-11e5-9ec9-eaed2826330d.png">
