### PR TITLE
Keep trying shorter postcodes until Adzuna finds a location

### DIFF
--- a/situational/apps/job_discovery/adzuna.py
+++ b/situational/apps/job_discovery/adzuna.py
@@ -51,12 +51,19 @@ class Adzuna(object):
             page += 1
 
     def locations_for_postcode(self, postcode):
-        endpoint = "jobs/gb/geodata/"
-        params = {
-            "where": postcode,
-        }
-        results = self._base_request(endpoint, params)
-        area = results.json()['location']['area']
+        def _get_area(postcode):
+            endpoint = "jobs/gb/geodata/"
+            params = {
+                "where": postcode,
+            }
+            results = self._base_request(endpoint, params)
+            return results.json()['location']['area']
+        area = _get_area(postcode)
+        # If the postcode isn't found, try a shorter version of it.
+        # this is a work around for problems with the Adzuna API.
+        while len(area) < 3 and len(postcode) > 0:
+            postcode = postcode[:-1]
+            area = _get_area(postcode)
         assert (len(area) >= 3)
         locations = area[:3]
         return locations


### PR DESCRIPTION
Not an amazing fix, but Adzuna sometimes only returns `[UK,]` as a location for some valid postcodes.  

Could be that they are newer than the copy of the PAF that Adzuna are using – hard to tell.  Nicely (?), Adzuna supports partial postcodes (not just out-codes), so removing characters one at a time will eventually return _something_.
