### PR TITLE
Remove test_get_suggestion_returns_random_job test

### DIFF
--- a/situational/apps/job_discovery/tests/test_models.py
+++ b/situational/apps/job_discovery/tests/test_models.py
@@ -50,18 +50,6 @@ class TestJobDiscoveryModel(BaseCase):
             self.job_2
         )
 
-    def test_get_suggestion_returns_random_job(self):
-        job_1_returned = 0
-        job_2_returned = 0
-        for x in range(500):
-            suggestion = self.report.get_suggestion()
-            if suggestion == self.job:
-                job_1_returned += 1
-            else:
-                job_2_returned += 1
-        self.assertTrue(225 <= job_1_returned <= 275)
-        self.assertTrue(225 <= job_2_returned <= 275)
-
     def test_get_suggestion_imports_jobs_if_needed(self):
         no_jobs_location = models.JobLocation.objects.create(
             adzuna_locations="UK,London,Central London"


### PR DESCRIPTION
Removing this test due to random test failure if one of the `self.assertTrue(225 <= job_X_returned <= 275)` fails randomly (as we'd expect it to).

`self.report.get_suggestion()` is tested elsewhere, so this test isn't adding much.
