### PR TITLE
Remove chord use for sub tasks

### DIFF
--- a/situational/apps/travel_report/tasks.py
+++ b/situational/apps/travel_report/tasks.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from celery import chord, shared_task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from redlock import Redlock
 
@@ -25,22 +25,15 @@ def populate_report(report):
 
     logger.debug("Populating travel report '{}'".format(report.postcode))
 
-    sub_tasks = (
-        travel_times_map.si(report),
-    )
-    callback = release_lock.si(report.pk, lock)
-    for task in sub_tasks + (callback,):
-        task.set(expires=population_timeout)
-    chord(sub_tasks, callback).delay()
+    travel_times_map(report)
+    release_lock(report.pk, lock)
 
 
-@shared_task
 def release_lock(identifier, lock):
     logger.debug("Releasing lock for travel report '{}'".format(identifier))
     dlm.unlock(lock)
 
 
-@shared_task
 def travel_times_map(report):
     logger.debug("Getting travel times map")
     travel_times_map, _created = TravelTimesMap.objects.get_or_create(

--- a/situational/celery.py
+++ b/situational/celery.py
@@ -18,5 +18,4 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 app.conf.update(
     DEBUG=False,
     BROKER_URL=os.environ.get('CELERY_BROKER_URL', settings.REDIS_URL),
-    CELERY_RESULT_BACKEND=settings.REDIS_URL,
 )


### PR DESCRIPTION
We were getting increasing number of connections on Redis.
There is no longer any obvious need for subtasks because only one task is being performed per report (used to be more, eg on sectors tool). 
We are running this on a free Heroku setup and the number of Redis connections is throwing errors. 
